### PR TITLE
add singleton traits

### DIFF
--- a/src/implements.jl
+++ b/src/implements.jl
@@ -15,7 +15,8 @@ Without specifying `Options`, the return value specifies that at least
 all the mandatory components of the interace are implemented.
 """
 function implements end
-implements(::Type{<:Interface}, obj) = false
+implements(T::Type{<:Interface}, obj) = implements(T, typeof(obj))
+implements(::Type{<:Interface}, obj::Type) = false
 
 """
     @implements(interface, objtype)
@@ -67,3 +68,23 @@ end
 
 _all_in(items::Tuple, collection) = all(map(in(collection), items))
 _all_in(item::Symbol, collection) = in(item, collection)
+
+struct Implemented{T<:Interface} end
+struct NotImplemented{T<:Interface} end
+
+"""
+    implemented_trait(T::Type{<:Interface}, obj)
+    implemented_trait(T::Type{<:Interface{Option}}, obj)
+
+Provides a single type for using interface implementation
+as a trait.
+
+Returns `Implemented{T}()` or `NotImplemented{T}`.
+"""
+function implemented_trait(::Type{T}, obj) where T<:Interface
+    if implements(T, obj)
+        Implemented{T}()
+    else
+        NotImplemented{T}()
+    end
+end

--- a/src/implements.jl
+++ b/src/implements.jl
@@ -79,7 +79,7 @@ struct NotImplemented{T<:Interface} end
 Provides a single type for using interface implementation
 as a trait.
 
-Returns `Implemented{T}()` or `NotImplemented{T}`.
+Returns `Implemented{T}()` or `NotImplemented{T}()`.
 """
 function implemented_trait(::Type{T}, obj) where T<:Interface
     if implements(T, obj)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,9 +41,13 @@ Animals.talk(::Duck) = :quack
 @testset "duck" begin
     ducks = [Duck(1), Duck(2)]
     @test Interfaces.implements(Animals.AnimalInterface, Duck) == true
+    @test Interfaces.implements(Animals.AnimalInterface, first(ducks)) == true
     @test Interfaces.implements(Animals.AnimalInterface{:dig}, Duck) == false
+    @test Interfaces.implements(Animals.AnimalInterface{:dig}, first(ducks)) == false
     @test @inferred Interfaces.implemented_trait(Animals.AnimalInterface{:walk}, Duck) == Interfaces.Implemented{Animals.AnimalInterface{:walk}}()
+    @test @inferred Interfaces.implemented_trait(Animals.AnimalInterface{:walk}, first(ducks)) == Interfaces.Implemented{Animals.AnimalInterface{:walk}}()
     @test @inferred Interfaces.implemented_trait(Animals.AnimalInterface{:dig}, Duck) == Interfaces.NotImplemented{Animals.AnimalInterface{:dig}}()
+    @test @inferred Interfaces.implemented_trait(Animals.AnimalInterface{:dig}, first(ducks)) == Interfaces.NotImplemented{Animals.AnimalInterface{:dig}}()
     @test Interfaces.test(Animals.AnimalInterface, Duck, ducks) == true
     @test Interfaces.test(Animals.AnimalInterface{(:walk,:talk)}, Duck, ducks) == true
     # TODO wrap errors somehow, or just let Invariants.jl handle that.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,8 @@ Animals.talk(::Duck) = :quack
     ducks = [Duck(1), Duck(2)]
     @test Interfaces.implements(Animals.AnimalInterface, Duck) == true
     @test Interfaces.implements(Animals.AnimalInterface{:dig}, Duck) == false
+    @test @inferred Interfaces.implemented_trait(Animals.AnimalInterface{:walk}, Duck) == Interfaces.Implemented{Animals.AnimalInterface{:walk}}()
+    @test @inferred Interfaces.implemented_trait(Animals.AnimalInterface{:dig}, Duck) == Interfaces.NotImplemented{Animals.AnimalInterface{:dig}}()
     @test Interfaces.test(Animals.AnimalInterface, Duck, ducks) == true
     @test Interfaces.test(Animals.AnimalInterface{(:walk,:talk)}, Duck, ducks) == true
     # TODO wrap errors somehow, or just let Invariants.jl handle that.


### PR DESCRIPTION
This PR adds `Implemented{T}` and `NotImplemented{T}` traits for use in dispatch, as an alternative to the `true`/`false` return values of `implements`.

Bikeshedding on what to call the function requested, `implemented_trait` isn't amazing.

Also realised we were not accepting objects, just types, and that really doesn't make sense for traits. So now we accept and test that passing objects to `implements` and `implemented_trait` works.

@gdalle if you want to review that would help