### PR TITLE
add some more interfaces to BaseInterfaces.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - name: Run BaseInterfaces tests
-        run: julia --project=BaseInterfaces -e 'using Pkg; pkg"dev ."; pkg"dev ./BaseInterfaces"; pkg"update"; pkg"test BaseInterfaces"'
+        run: julia --project=BaseInterfaces -e 'using Pkg; pkg"dev ."; pkg"update"; pkg"test"'
         shell: bash
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,12 +36,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - name: Run BaseInterfaces tests
-        run: julia --project=BaseInterfaces -e '
-          using Pkg
-          pkg"dev ."
-          pkg"dev ./BaseInterfaces"
-          pkg"update"
-          pkg"test BaseInterfaces"'
+        run: julia --project=BaseInterfaces -e 'using Pkg; pkg"dev ."; pkg"dev ./BaseInterfaces"; pkg"update"; pkg"test BaseInterfaces"'
         shell: bash
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.7'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -35,27 +35,15 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - name: Run BaseInterfaces tests
+        run: julia --project=BaseInterfaces -e '
+          using Pkg
+          pkg"dev ."
+          pkg"dev ./BaseInterfaces"
+          pkg"update"
+          pkg"test BaseInterfaces"'
+        shell: bash
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
         with:
           files: lcov.info
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: '1'
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-docdeploy@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: |
-          julia --project=docs -e '
-            using Documenter: DocMeta, doctest
-            using Interfaces
-            DocMeta.setdocmeta!(Interfaces, :DocTestSetup, :(using Interfaces); recursive=true)
-            doctest(Interfaces)'

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           version: '1'
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; pkg"dev ."; pkg"dev BaseInterfaces"; Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; pkg"dev ."; pkg"dev ./BaseInterfaces"; Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,27 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main # update to match your development branch (master, main, dev, trunk, ...)
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; pkg"dev ."; pkg"dev BaseInterfaces"; Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # If authenticating with SSH deploy key
+        run: julia --project=docs/ docs/make.jl

--- a/BaseInterfaces/README.md
+++ b/BaseInterfaces/README.md
@@ -1,6 +1,36 @@
 # BaseInterfaces
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://rafaqz.github.io/BaseInterfaces.jl/stable/)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://rafaqz.github.io/BaseInterfaces.jl/dev/)
-[![Build Status](https://github.com/rafaqz/BaseInterfaces.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/rafaqz/BaseInterfaces.jl/actions/workflows/CI.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/rafaqz/BaseInterfaces.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/rafaqz/BaseInterfaces.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://rafaqz.github.io/Interfaces.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://rafaqz.github.io/Interfaces.jl/dev/)
+[![Build Status](https://github.com/rafaqz/Interfaces.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/rafaqz/Interfaces.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/rafaqz/Interfaces.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/rafaqz/Interfaces.jl)
+
+BaseInterfaces.jl is a subpackage of Interfaces.jl that provides predifined 
+definition and testing for Base Julia interfaces.
+
+Currently this includes:
+- A general iteration interface: `IterationInterface`
+- `AbstractArray` interface: `ArrayInterface`
+- `AbstractSet` interface: `SetInterface`
+- `AbstractDict` interface: `DictInterface`
+
+
+Testing your object follows the interfaces is as simple as:
+
+```julia
+using BaseInterfaces, Interfaces
+Interfaces.tests(DictInterface, MyDict, [mydict1, mydict2, ...])
+```
+
+Declaring that it follows the interface is done with:
+
+```julia
+@implements DictInterface{(:optional, :components)} MyDict
+```
+
+Where components can be chosen from `Interfaces.optional_keys(DictInterface)`.
+
+See [the docs](https://rafaqz.github.io/Interfaces.jl/stable/) for use.
+
+If you want to add more Base julia interfaces here, or think the existing 
+ones could be improved, please make an issue or pull request.

--- a/BaseInterfaces/README.md
+++ b/BaseInterfaces/README.md
@@ -25,7 +25,7 @@ Interfaces.tests(DictInterface, MyDict, [mydict1, mydict2, ...])
 Declaring that it follows the interface is done with:
 
 ```julia
-@implements DictInterface{(:optional, :components)} MyDict
+@implements DictInterface{(:component1, :component2)} MyDict
 ```
 
 Where components can be chosen from `Interfaces.optional_keys(DictInterface)`.

--- a/BaseInterfaces/src/BaseInterfaces.jl
+++ b/BaseInterfaces/src/BaseInterfaces.jl
@@ -10,13 +10,13 @@ include("set.jl")
 include("array.jl")
 
 # Some example interface delarations.
-@implements IterationInterface{(:reverse,:indexing,)} UnitRange
-@implements IterationInterface{(:reverse,:indexing,)} StepRange
-@implements IterationInterface{(:reverse,:indexing,)} Array
-@implements IterationInterface{(:reverse,)} Base.Generator
-@implements IterationInterface{(:reverse,:indexing,)} Tuple
-
-@implements SetInterface Set
+@implements ArrayInterface Base.LogicalIndex # No getindex
+@implements ArrayInterface{(:getindex,)} UnitRange
+@implements ArrayInterface{(:getindex,)} StepRange
+@implements ArrayInterface{(:getindex,:setindex,)} Array
+@implements ArrayInterface{(:getindex,:setindex,)} SubArray
+@implements ArrayInterface{(:getindex,:setindex,)} PermutedDimsArray
+@implements ArrayInterface{(:getindex,:setindex,)} Base.ReshapedArray
 
 @implements DictInterface{(:setindex,)} Dict
 @implements DictInterface{(:setindex,)} IdDict
@@ -26,13 +26,13 @@ include("array.jl")
 @implements DictInterface Base.ImmutableDict
 @implements DictInterface Base.Pairs
 
-# Some example interface delarations.
-@implements ArrayInterface Base.LogicalIndex # No getindex
-@implements ArrayInterface{(:getindex,)} UnitRange
-@implements ArrayInterface{(:getindex,)} StepRange
-@implements ArrayInterface{(:getindex,:setindex,)} Array
-@implements ArrayInterface{(:getindex,:setindex,)} SubArray
-@implements ArrayInterface{(:getindex,:setindex,)} PermutedDimsArray
-@implements ArrayInterface{(:getindex,:setindex,)} Base.ReshapedArray
+@implements IterationInterface{(:reverse,:indexing,)} UnitRange
+@implements IterationInterface{(:reverse,:indexing,)} StepRange
+@implements IterationInterface{(:reverse,:indexing,)} Array
+@implements IterationInterface{(:reverse,)} Base.Generator
+@implements IterationInterface{(:reverse,:indexing,)} Tuple
+
+@implements SetInterface Set
+@implements SetInterface BitSet
 
 end

--- a/BaseInterfaces/src/BaseInterfaces.jl
+++ b/BaseInterfaces/src/BaseInterfaces.jl
@@ -2,9 +2,12 @@ module BaseInterfaces
 
 using Interfaces
 
-export IterationInterface
+export ArrayInterface, DictInterface, IterationInterface, SetInterface
 
 include("iteration.jl")
+include("dict.jl")
+include("set.jl")
+include("array.jl")
 
 # Some example interface delarations.
 @implements IterationInterface{(:reverse,:indexing,)} UnitRange
@@ -12,5 +15,24 @@ include("iteration.jl")
 @implements IterationInterface{(:reverse,:indexing,)} Array
 @implements IterationInterface{(:reverse,)} Base.Generator
 @implements IterationInterface{(:reverse,:indexing,)} Tuple
+
+@implements SetInterface Set
+
+@implements DictInterface{(:setindex,)} Dict
+@implements DictInterface{(:setindex,)} IdDict
+# @implements DictInterface GenericDict
+# @implements DictInterface{(:setindex,)} WeakKeyDict
+@implements DictInterface Base.EnvDict
+@implements DictInterface Base.ImmutableDict
+@implements DictInterface Base.Pairs
+
+# Some example interface delarations.
+@implements ArrayInterface Base.LogicalIndex # No getindex
+@implements ArrayInterface{(:getindex,)} UnitRange
+@implements ArrayInterface{(:getindex,)} StepRange
+@implements ArrayInterface{(:getindex,:setindex,)} Array
+@implements ArrayInterface{(:getindex,:setindex,)} SubArray
+@implements ArrayInterface{(:getindex,:setindex,)} PermutedDimsArray
+@implements ArrayInterface{(:getindex,:setindex,)} Base.ReshapedArray
 
 end

--- a/BaseInterfaces/src/BaseInterfaces.jl
+++ b/BaseInterfaces/src/BaseInterfaces.jl
@@ -14,8 +14,6 @@ include("array.jl")
 # @implements ArrayInterface Base.LogicalIndex # No getindex
 @implements ArrayInterface UnitRange
 @implements ArrayInterface StepRange
-@implements ArrayInterface LinRange
-@implements ArrayInterface Base.OneTo
 @implements ArrayInterface Base.Slice
 @implements ArrayInterface Base.IdentityUnitRange
 @implements ArrayInterface Base.CodeUnits
@@ -35,8 +33,8 @@ include("array.jl")
 @implements IterationInterface{(:reverse,:indexing,)} UnitRange
 @implements IterationInterface{(:reverse,:indexing,)} StepRange
 @implements IterationInterface{(:reverse,:indexing,)} Array
-@implements IterationInterface{(:reverse,)} Base.Generator
 @implements IterationInterface{(:reverse,:indexing,)} Tuple
+@implements IterationInterface{(:reverse,)} Base.Generator
 
 # TODO add grouping to reduce the number of options
 @implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:empty!,:delete!,:push!,:copymutable,:sizehint)} Set

--- a/BaseInterfaces/src/BaseInterfaces.jl
+++ b/BaseInterfaces/src/BaseInterfaces.jl
@@ -28,7 +28,7 @@ include("array.jl")
 @implements DictInterface{(:setindex,)} WeakKeyDict
 @implements DictInterface Base.EnvDict
 @implements DictInterface Base.ImmutableDict
-@implements DictInterface Base.Pairs
+# @implements DictInterface Base.Pairs - not on 1.6?
 
 @implements IterationInterface{(:reverse,:indexing,)} UnitRange
 @implements IterationInterface{(:reverse,:indexing,)} StepRange

--- a/BaseInterfaces/src/BaseInterfaces.jl
+++ b/BaseInterfaces/src/BaseInterfaces.jl
@@ -10,18 +10,24 @@ include("set.jl")
 include("array.jl")
 
 # Some example interface delarations.
-@implements ArrayInterface Base.LogicalIndex # No getindex
-@implements ArrayInterface{(:getindex,)} UnitRange
-@implements ArrayInterface{(:getindex,)} StepRange
-@implements ArrayInterface{(:getindex,:setindex,)} Array
-@implements ArrayInterface{(:getindex,:setindex,)} SubArray
-@implements ArrayInterface{(:getindex,:setindex,)} PermutedDimsArray
-@implements ArrayInterface{(:getindex,:setindex,)} Base.ReshapedArray
+
+# @implements ArrayInterface Base.LogicalIndex # No getindex
+@implements ArrayInterface UnitRange
+@implements ArrayInterface StepRange
+@implements ArrayInterface LinRange
+@implements ArrayInterface Base.OneTo
+@implements ArrayInterface Base.Slice
+@implements ArrayInterface Base.IdentityUnitRange
+@implements ArrayInterface Base.CodeUnits
+@implements ArrayInterface{(:setindex!,:similar_type,:similar_eltype,:similar_size)} Array
+@implements ArrayInterface{(:setindex!,:similar_type,:similar_size)} BitArray
+@implements ArrayInterface{(:setindex!,)} SubArray
+@implements ArrayInterface{(:setindex!,)} PermutedDimsArray
+@implements ArrayInterface{(:setindex!,)} Base.ReshapedArray
 
 @implements DictInterface{(:setindex,)} Dict
 @implements DictInterface{(:setindex,)} IdDict
-# @implements DictInterface GenericDict
-# @implements DictInterface{(:setindex,)} WeakKeyDict
+@implements DictInterface{(:setindex,)} WeakKeyDict
 @implements DictInterface Base.EnvDict
 @implements DictInterface Base.ImmutableDict
 @implements DictInterface Base.Pairs
@@ -32,7 +38,9 @@ include("array.jl")
 @implements IterationInterface{(:reverse,)} Base.Generator
 @implements IterationInterface{(:reverse,:indexing,)} Tuple
 
-@implements SetInterface Set
-@implements SetInterface BitSet
+# TODO add grouping to reduce the number of options
+@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:empty!,:delete!,:push!,:copymutable,:sizehint)} Set
+@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:empty!,:delete!,:push!,:copymutable,:sizehint)} BitSet
+@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint)} Base.KeySet
 
 end

--- a/BaseInterfaces/src/BaseInterfaces.jl
+++ b/BaseInterfaces/src/BaseInterfaces.jl
@@ -9,36 +9,6 @@ include("dict.jl")
 include("set.jl")
 include("array.jl")
 
-# Some example interface delarations.
-
-# @implements ArrayInterface Base.LogicalIndex # No getindex
-@implements ArrayInterface UnitRange
-@implements ArrayInterface StepRange
-@implements ArrayInterface Base.Slice
-@implements ArrayInterface Base.IdentityUnitRange
-@implements ArrayInterface Base.CodeUnits
-@implements ArrayInterface{(:setindex!,:similar_type,:similar_eltype,:similar_size)} Array
-@implements ArrayInterface{(:setindex!,:similar_type,:similar_size)} BitArray
-@implements ArrayInterface{(:setindex!,)} SubArray
-@implements ArrayInterface{(:setindex!,)} PermutedDimsArray
-@implements ArrayInterface{(:setindex!,)} Base.ReshapedArray
-
-@implements DictInterface{(:setindex,)} Dict
-@implements DictInterface{(:setindex,)} IdDict
-@implements DictInterface{(:setindex,)} WeakKeyDict
-@implements DictInterface Base.EnvDict
-@implements DictInterface Base.ImmutableDict
-# @implements DictInterface Base.Pairs - not on 1.6?
-
-@implements IterationInterface{(:reverse,:indexing,)} UnitRange
-@implements IterationInterface{(:reverse,:indexing,)} StepRange
-@implements IterationInterface{(:reverse,:indexing,)} Array
-@implements IterationInterface{(:reverse,:indexing,)} Tuple
-@implements IterationInterface{(:reverse,)} Base.Generator
-
-# TODO add grouping to reduce the number of options
-@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:empty!,:delete!,:push!,:copymutable,:sizehint)} Set
-@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:empty!,:delete!,:push!,:copymutable,:sizehint)} BitSet
-@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint)} Base.KeySet
+include("implementations.jl")
 
 end

--- a/BaseInterfaces/src/array.jl
+++ b/BaseInterfaces/src/array.jl
@@ -90,4 +90,4 @@ array_components = (;
 
 _wrappertype(A) = Base.typename(typeof(A)).wrapper
 
-@interface ArrayInterface array_components "Base Julia AbstractArray interface"
+@interface ArrayInterface AbstractArray array_components "Base Julia AbstractArray interface"

--- a/BaseInterfaces/src/array.jl
+++ b/BaseInterfaces/src/array.jl
@@ -1,16 +1,93 @@
-@interface ArrayInterface (
-    mandatory = (
-        iterate = A -> Interfaces.test(IterationInterface, A; show=false),
-        ndims = A -> ndims(A) isa Int,
+#= Abstract Arrays
+
+Methods to implement		            Brief description
+size(A)		                            Returns a tuple containing the dimensions of A
+getindex(A, i::Int)		                (if IndexLinear) Linear scalar indexing
+getindex(A, I::Vararg{Int, N})          (if IndexCartesian, where N = ndims(A)) N-dimensional scalar indexing
+
+Optional methods	                    Default definition	                    Brief description
+IndexStyle(::Type)	                    IndexCartesian()	                    Returns either IndexLinear() or IndexCartesian(). See the description below.
+setindex!(A, v, i::Int)		                                                    (if IndexLinear) Scalar indexed assignment
+setindex!(A, v, I::Vararg{Int, N})                                              (if IndexCartesian, where N = ndims(A)) N-dimensional scalar indexed assignment
+getindex(A, I...)	                    defined in terms of scalar getindex	    Multidimensional and nonscalar indexing
+setindex!(A, X, I...)	                defined in terms of scalar setindex!	Multidimensional and nonscalar indexed assignment 
+iterate	                                defined in terms of scalar getindex	Iteration
+length(A)	                            prod(size(A))	                        Number of elements
+similar(A)	                            similar(A, eltype(A), size(A))	        Return a mutable array with the same shape and element type
+similar(A, ::Type{S})	                similar(A, S, size(A))	                Return a mutable array with the same shape and the specified element type
+similar(A, dims::Dims)	                similar(A, eltype(A), dims)	            Return a mutable array with the same element type and size dims
+similar(A, ::Type{S}, dims::Dims)	    Array{S}(undef, dims)	                Return a mutable array with the specified element type and size
+
+Non-traditional indices	                Default definition	                    Brief description
+axes(A)	                                map(OneTo, size(A))	                    Return a tuple of AbstractUnitRange{<:Integer} of valid indices
+similar(A, ::Type{S}, inds)	            similar(A, S, Base.to_shape(inds))	    Return a mutable array with the specified indices inds (see below)
+similar(T::Union{Type,Function}, inds)	T(Base.to_shape(inds))	                Return an array similar to T with the specified indices inds (see below)
+=#
+
+# And arbitrary new type for array values
+struct ArrayTestVal
+    a::Int
+end
+
+# In case `eltype` and `ndims` have custom methods
+# We should always be able to use these to mean the same thing
+_eltype(::AbstractArray{T}) where T = T
+_ndims(::AbstractArray{<:Any,N}) where N = N
+
+array_components = (;
+    mandatory = (;
+        type = A -> A isa AbstractArray,
+        eltype = (
+            A -> eltype(A) isa Type,
+            A -> eltype(A) == _eltype(A),
+        ),
+        ndims = (
+            A -> ndims(A) isa Int,
+            A -> ndims(A) == _ndims(A),
+        ),
         size = (
             A -> size(A) isa NTuple{<:Any,Int},
             A -> length(size(A)) == ndims(A),
         ),
-        eltype = A -> typeof(first(iterate(A))) <: eltype(A)
+        getindex = (
+            A -> A[begin] isa eltype(A),
+            A -> A[map(first, axes(A))...] isa eltype(A),
+        ),
+        indexstyle = A -> IndexStyle(A) in (IndexCartesian(), IndexLinear()),
     ),
     # TODO implement all the optional conditions
     optional = (;
-        getindex = A -> true,
-        setindex = A -> true,
-    ),
-) "Base Julia AbstractArray interface"
+        setindex! = (
+            A -> length(A) > 1 || throw(ArgumentError("Test arrays must have more than one element to test setindex!")),
+            A -> begin
+                # Tests setindex! by simply swapping the first and last elements
+                x1 = A[begin]; x2 = A[end]
+                A[begin] = x2
+                A[end] = x1
+                A[begin] == x2 && A[end] == x1
+            end,
+            A -> begin
+                fs = map(first, axes(A))
+                ls = map(last, axes(A))
+                x1 = A[fs...]; 
+                x2 = A[ls...]
+                A[fs...] = x2
+                A[ls...] = x1
+                A[fs...] == x2 && A[ls...] == x1
+            end,
+        ),
+        similar_type = A -> similar(A) isa typeof(A),
+        similar_eltype = A -> begin
+            A1 = similar(A, ArrayTestVal) 
+            eltype(A1) == ArrayTestVal && _wrappertype(A) == _wrappertype(A1)
+        end,
+        similar_size = A -> begin
+            A1 = similar(A, (2, 3))
+            size(A1) == (2, 3) && _wrappertype(A) == _wrappertype(A1)
+        end,
+    )
+)
+
+_wrappertype(A) = Base.typename(typeof(A)).wrapper
+
+@interface ArrayInterface array_components "Base Julia AbstractArray interface"

--- a/BaseInterfaces/src/array.jl
+++ b/BaseInterfaces/src/array.jl
@@ -1,0 +1,16 @@
+@interface ArrayInterface (
+    mandatory = (
+        iterate = A -> Interfaces.test(IterationInterface, A),
+        ndims = A -> ndims(A) isa Int,
+        size = (
+            A -> size(A) isa NTuple{<:Any,Int},
+            A -> length(size(A)) == ndims(A),
+        ),
+        eltype = A -> typeof(first(iterate(A))) <: eltype(A)
+    ),
+    # TODO implement all the optional conditions
+    optional = (;
+        getindex = A -> true,
+        setindex = A -> true,
+    ),
+) "Base Julia AbstractArray interface"

--- a/BaseInterfaces/src/array.jl
+++ b/BaseInterfaces/src/array.jl
@@ -10,7 +10,7 @@ IndexStyle(::Type)	                    IndexCartesian()	                    Retu
 setindex!(A, v, i::Int)		                                                    (if IndexLinear) Scalar indexed assignment
 setindex!(A, v, I::Vararg{Int, N})                                              (if IndexCartesian, where N = ndims(A)) N-dimensional scalar indexed assignment
 getindex(A, I...)	                    defined in terms of scalar getindex	    Multidimensional and nonscalar indexing
-setindex!(A, X, I...)	                defined in terms of scalar setindex!	Multidimensional and nonscalar indexed assignment 
+setindex!(A, X, I...)	                defined in terms of scalar setindex!	Multidimensional and nonscalar indexed assignment
 iterate	                                defined in terms of scalar getindex	Iteration
 length(A)	                            prod(size(A))	                        Number of elements
 similar(A)	                            similar(A, eltype(A), size(A))	        Return a mutable array with the same shape and element type
@@ -46,45 +46,80 @@ array_components = (;
             A -> ndims(A) == _ndims(A),
         ),
         size = (
-            A -> size(A) isa NTuple{<:Any,Int},
-            A -> length(size(A)) == ndims(A),
+            "size(A) returns a tuple of Integer" => A -> size(A) isa NTuple{<:Any,Integer},
+            "length of size(A) matches ndims(A)" => A -> length(size(A)) == ndims(A),
         ),
         getindex = (
-            A -> A[begin] isa eltype(A),
-            A -> A[map(first, axes(A))...] isa eltype(A),
+           "Can index with begin/firstinex" => A -> A[begin] isa eltype(A),
+           "Can index with end/lastindex" => A -> A[end] isa eltype(A),
+           "Can index with all indices in `eachindex(A)`" => A -> all(x -> A[x] isa eltype(A), eachindex(A)),
+           "Can index with multiple dimensions" => A -> A[map(first, axes(A))...] isa eltype(A),
+           "Can use trailing ones" => A -> A[map(first, axes(A))..., 1, 1, 1] isa eltype(A),
+           "Can index with CartesianIndex" => A -> A[CartesianIndex(map(first, axes(A))...)] isa eltype(A),
+           "Can use trailing ones in CartesianIndex" => A -> A[CartesianIndex(map(first, axes(A))..., 1, 1, 1)] isa eltype(A),
         ),
-        indexstyle = A -> IndexStyle(A) in (IndexCartesian(), IndexLinear()),
+        indexstyle = "IndexStyle returns IndexCartesian or IndexLinear" => A -> IndexStyle(A) in (IndexCartesian(), IndexLinear()),
     ),
     # TODO implement all the optional conditions
     optional = (;
         setindex! = (
             A -> length(A) > 1 || throw(ArgumentError("Test arrays must have more than one element to test setindex!")),
-            A -> begin
-                # Tests setindex! by simply swapping the first and last elements
-                x1 = A[begin]; x2 = A[end]
-                A[begin] = x2
-                A[end] = x1
-                A[begin] == x2 && A[end] == x1
-            end,
-            A -> begin
-                fs = map(first, axes(A))
-                ls = map(last, axes(A))
-                x1 = A[fs...]; 
-                x2 = A[ls...]
-                A[fs...] = x2
-                A[ls...] = x1
-                A[fs...] == x2 && A[ls...] == x1
-            end,
+            "setindex! can write the first to the last element" => 
+                A -> begin
+                    x1 = A[begin]; x2 = A[end]
+                    A[begin] = x2
+                    A[end] = x1
+                    A[begin] == x2 && A[end] == x1
+                end,
+            "setindex! can write the first to the last element using multidimensional indices" =>
+                A -> begin
+                    fs = map(first, axes(A))
+                    ls = map(last, axes(A))
+                    x1 = A[fs...];
+                    x2 = A[ls...]
+                    A[fs...] = x2
+                    A[ls...] = x1
+                    A[fs...] == x2 && A[ls...] == x1
+                end,
+            "setindex! can write to all indices in eachindex(A)" => 
+                A -> begin
+                    v = first(A)
+                    all(eachindex(A)) do i
+                        A[i] = v
+                        A[i] === v
+                    end
+                end,
+            "setindex! can write to all indices in CartesianIndices(A)" => 
+                A -> begin
+                    v = first(A) # We have already tested writing to the first index above
+                    all(CartesianIndices(A)) do i
+                        A[i] = v
+                        A[i] === v
+                    end
+                end,
         ),
-        similar_type = A -> similar(A) isa typeof(A),
-        similar_eltype = A -> begin
-            A1 = similar(A, ArrayTestVal) 
-            eltype(A1) == ArrayTestVal && _wrappertype(A) == _wrappertype(A1)
-        end,
-        similar_size = A -> begin
-            A1 = similar(A, (2, 3))
-            size(A1) == (2, 3) && _wrappertype(A) == _wrappertype(A1)
-        end,
+        similar_type = "`similar(A)` returns an object the same type and size as `A`" => 
+            A -> begin
+                A1 = similar(A)
+                A1 isa typeof(A) && size(A1) == size(A)
+            end,
+        similar_eltype = "similar(A, T::Type) returns an object the same base type as `A` with eltype of `T`" => 
+            A -> begin
+                A1 = similar(A, ArrayTestVal); 
+                _wrappertype(A) == _wrappertype(A1) && eltype(A1) == ArrayTestVal && size(A) == size(A1)
+            end,
+        similar_size = "similar(A, s::NTuple{Int}) returns an object the same type as `A` with size `s`" =>
+            A -> begin
+                A1 = similar(A, (2, 3))
+                A2 = similar(A, (4, 5))
+                _wrappertype(A) == _wrappertype(A1) && size(A1) == (2, 3) && size(A2) == (4, 5)
+            end,
+        similar_eltype_size = "similar(A, T::Type, s::NTuple{Int}) returns an object the same type as `A` with eltype `T` and size `s`" =>
+            A -> begin
+                A1 = similar(A, ArrayTestVal, (2, 3))
+                A2 = similar(A, ArrayTestVal, (4, 5))
+                _wrappertype(A) == _wrappertype(A1) && eltype(A1) == ArrayTestVal && size(A1) == (2, 3) && size(A2) == (4, 5) 
+            end,
     )
 )
 

--- a/BaseInterfaces/src/array.jl
+++ b/BaseInterfaces/src/array.jl
@@ -1,4 +1,5 @@
 #= Abstract Arrays
+https://docs.julialang.org/en/v1/manual/interfaces/
 
 Methods to implement		            Brief description
 size(A)		                            Returns a tuple containing the dimensions of A

--- a/BaseInterfaces/src/array.jl
+++ b/BaseInterfaces/src/array.jl
@@ -1,6 +1,6 @@
 @interface ArrayInterface (
     mandatory = (
-        iterate = A -> Interfaces.test(IterationInterface, A),
+        iterate = A -> Interfaces.test(IterationInterface, A; show=false),
         ndims = A -> ndims(A) isa Int,
         size = (
             A -> size(A) isa NTuple{<:Any,Int},

--- a/BaseInterfaces/src/collection.jl
+++ b/BaseInterfaces/src/collection.jl
@@ -1,0 +1,20 @@
+# Should iteration be here?
+
+mandatory = (;
+    isempty = !isempty,
+)
+
+optional = (; 
+    empty! = c -> isempty(empty!(c)),
+    length = c -> length(c) isa Integer,
+    # push! = 
+    # pushfirst! = 
+    # deleteat! = 
+    # splice! = 
+    # pop! = 
+    # popfirst! = 
+)
+
+components = (; mandatory, optional)
+
+@interface CollectionInterface Any _components "Base interface for shared methods of various collections"

--- a/BaseInterfaces/src/dict.jl
+++ b/BaseInterfaces/src/dict.jl
@@ -2,7 +2,7 @@
 @interface DictInterface (
     mandatory = (;
         type = a -> a.d isa AbstractDict,
-        iterate = a -> Interfaces.test(IterationInterface, a.d) && first(iterate(a.d)) isa Pair,
+        iterate = a -> Interfaces.test(IterationInterface, a.d; show=false) && first(iterate(a.d)) isa Pair,
         eltype = a -> eltype(a.d) <: Pair,
         getindex = a -> a.d[first(keys(a.d))] === last(first(iterate(a.d))),
     ),

--- a/BaseInterfaces/src/dict.jl
+++ b/BaseInterfaces/src/dict.jl
@@ -1,15 +1,21 @@
 
-@interface DictInterface AbstractDict (
+@interface DictInterface AbstractDict ( # <: CollectionInterface
     mandatory = (;
         iterate = a -> Interfaces.test(IterationInterface, a.d; show=false) && first(iterate(a.d)) isa Pair,
+        # keytype = (
+            # a -> keytype(typeof(a.d)) isa Type,
+            # a -> keytype(typeof(a.d)) isa typeof(eltype(a.d)),
+        # ),
         eltype = a -> eltype(a.d) <: Pair,
         getindex = a -> a.d[first(keys(a.d))] === last(first(iterate(a.d))),
+        keys = a -> all(k -> k isa keytype(a.d), keys(a.d)),
+        values = a -> all(v -> v isa valtype(a.d), values(a.d)),
     ),
     optional = (;
-        setindex = a -> begin
-            a.d[a.k] = a.v
-            a.d[a.k] == a.v
-        end,
+        setindex! = (
+            a -> !haskey(a.d, a.k),
+            a -> (a.d[a.k] = a.v; a.d[a.k] == a.v),
+        ),
     )
 ) """
 `AbstractDict` interface requires Arguments, with `d = the_dict` mandatory, and

--- a/BaseInterfaces/src/dict.jl
+++ b/BaseInterfaces/src/dict.jl
@@ -1,0 +1,18 @@
+
+@interface DictInterface (
+    mandatory = (;
+        type = a -> a.d isa AbstractDict,
+        iterate = a -> Interfaces.test(IterationInterface, a.d) && first(iterate(a.d)) isa Pair,
+        eltype = a -> eltype(a.d) <: Pair,
+        getindex = a -> a.d[first(keys(a.d))] === last(first(iterate(a.d))),
+    ),
+    optional = (;
+        setindex = a -> begin
+            a.d[a.k] = a.v
+            a.d[a.k] == a.v
+        end,
+    )
+) """
+`AbstractDict` interface requires Arguments, with `d = the_dict` mandatory, and
+when `setindex` is needed, `k = any_valid_key_not_in_d, v = any_valid_val`
+"""

--- a/BaseInterfaces/src/dict.jl
+++ b/BaseInterfaces/src/dict.jl
@@ -1,7 +1,6 @@
 
-@interface DictInterface (
+@interface DictInterface AbstractDict (
     mandatory = (;
-        type = a -> a.d isa AbstractDict,
         iterate = a -> Interfaces.test(IterationInterface, a.d; show=false) && first(iterate(a.d)) isa Pair,
         eltype = a -> eltype(a.d) <: Pair,
         getindex = a -> a.d[first(keys(a.d))] === last(first(iterate(a.d))),

--- a/BaseInterfaces/src/dict.jl
+++ b/BaseInterfaces/src/dict.jl
@@ -2,11 +2,9 @@
 @interface DictInterface AbstractDict ( # <: CollectionInterface
     mandatory = (;
         iterate = a -> Interfaces.test(IterationInterface, a.d; show=false) && first(iterate(a.d)) isa Pair,
-        # keytype = (
-            # a -> keytype(typeof(a.d)) isa Type,
-            # a -> keytype(typeof(a.d)) isa typeof(eltype(a.d)),
-        # ),
         eltype = a -> eltype(a.d) <: Pair,
+        keytype = a -> keytype(a.d) == eltype(a.d).parameters[1],
+        valtype = a -> valtype(a.d) == eltype(a.d).parameters[2],
         getindex = a -> a.d[first(keys(a.d))] === last(first(iterate(a.d))),
         keys = a -> all(k -> k isa keytype(a.d), keys(a.d)),
         values = a -> all(v -> v isa valtype(a.d), values(a.d)),

--- a/BaseInterfaces/src/dict.jl
+++ b/BaseInterfaces/src/dict.jl
@@ -1,18 +1,21 @@
 
 @interface DictInterface AbstractDict ( # <: CollectionInterface
     mandatory = (;
-        iterate = a -> Interfaces.test(IterationInterface, a.d; show=false) && first(iterate(a.d)) isa Pair,
-        eltype = a -> eltype(a.d) <: Pair,
+        iterate = "AbstractDict follows the IterationInterface" => a -> Interfaces.test(IterationInterface, a.d; show=false) && first(iterate(a.d)) isa Pair,
+        eltype = "eltype is a Pair" => a -> eltype(a.d) <: Pair,
         keytype = a -> keytype(a.d) == eltype(a.d).parameters[1],
         valtype = a -> valtype(a.d) == eltype(a.d).parameters[2],
-        getindex = a -> a.d[first(keys(a.d))] === last(first(iterate(a.d))),
         keys = a -> all(k -> k isa keytype(a.d), keys(a.d)),
         values = a -> all(v -> v isa valtype(a.d), values(a.d)),
+        getindex = (
+            a -> a.d[first(keys(a.d))] === first(values(a.d)),
+            a -> all(k -> a.d[k] isa valtype(a.d), keys(a.d)), 
+        ),
     ),
     optional = (;
         setindex! = (
-            a -> !haskey(a.d, a.k),
-            a -> (a.d[a.k] = a.v; a.d[a.k] == a.v),
+            "test object `d` does not yet have test key `k`" => a -> !haskey(a.d, a.k),
+            "can set key `k` to value `v`" => a -> (a.d[a.k] = a.v; a.d[a.k] == a.v),
         ),
     )
 ) """

--- a/BaseInterfaces/src/implementations.jl
+++ b/BaseInterfaces/src/implementations.jl
@@ -36,6 +36,6 @@
 @implements IterationInterface WeakKeyDict
 
 # TODO add grouping to reduce the number of options
-@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:empty!,:delete!,:push!,:copymutable,:sizehint)} Set
-@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:empty!,:delete!,:push!,:copymutable,:sizehint)} BitSet
-@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint)} Base.KeySet
+@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:union,:empty!,:delete!,:push!,:copymutable,:sizehint!)} Set
+@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:union,:empty!,:delete!,:push!,:copymutable,:sizehint!)} BitSet
+@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint!)} Base.KeySet

--- a/BaseInterfaces/src/implementations.jl
+++ b/BaseInterfaces/src/implementations.jl
@@ -17,7 +17,9 @@
 @implements DictInterface{:setindex!} WeakKeyDict
 @implements DictInterface Base.EnvDict
 @implements DictInterface Base.ImmutableDict
-# @implements DictInterface Base.Pairs - not on 1.6?
+@static if VERSION >= v"1.9.0"
+    @implements DictInterface Base.Pairs
+end
 
 @implements IterationInterface{(:reverse,:indexing)} UnitRange
 @implements IterationInterface{(:reverse,:indexing)} StepRange

--- a/BaseInterfaces/src/implementations.jl
+++ b/BaseInterfaces/src/implementations.jl
@@ -1,0 +1,41 @@
+# Some example interface delarations.
+
+# @implements ArrayInterface Base.LogicalIndex # No getindex
+@implements ArrayInterface UnitRange
+@implements ArrayInterface StepRange
+@implements ArrayInterface Base.Slice
+@implements ArrayInterface Base.IdentityUnitRange
+@implements ArrayInterface Base.CodeUnits
+@implements ArrayInterface{(:setindex!,:similar_type,:similar_eltype,:similar_size)} Array
+@implements ArrayInterface{(:setindex!,:similar_type,:similar_size)} BitArray
+@implements ArrayInterface{:setindex!} SubArray
+@implements ArrayInterface{:setindex!} PermutedDimsArray
+@implements ArrayInterface{:setindex!} Base.ReshapedArray
+
+@implements DictInterface{:setindex!} Dict
+@implements DictInterface{:setindex!} IdDict
+@implements DictInterface{:setindex!} WeakKeyDict
+@implements DictInterface Base.EnvDict
+@implements DictInterface Base.ImmutableDict
+# @implements DictInterface Base.Pairs - not on 1.6?
+
+@implements IterationInterface{(:reverse,:indexing)} UnitRange
+@implements IterationInterface{(:reverse,:indexing)} StepRange
+@implements IterationInterface{(:reverse,:indexing)} Array
+@implements IterationInterface{(:reverse,:indexing)} Tuple
+@implements IterationInterface{(:reverse,:indexing)} NamedTuple
+@implements IterationInterface{(:reverse,:indexing)} String
+@implements IterationInterface{(:reverse,:indexing)} Pair
+@implements IterationInterface{(:reverse,:indexing)} Number
+@implements IterationInterface{(:reverse,:indexing)} Base.EachLine
+@implements IterationInterface{(:reverse,)} Base.Generator
+@implements IterationInterface Set
+@implements IterationInterface BitSet
+@implements IterationInterface IdDict
+@implements IterationInterface Dict
+@implements IterationInterface WeakKeyDict
+
+# TODO add grouping to reduce the number of options
+@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:empty!,:delete!,:push!,:copymutable,:sizehint)} Set
+@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:empty!,:delete!,:push!,:copymutable,:sizehint)} BitSet
+@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint)} Base.KeySet

--- a/BaseInterfaces/src/iteration.jl
+++ b/BaseInterfaces/src/iteration.jl
@@ -1,5 +1,6 @@
 #=
-From the Base julia interface docs:
+From the Base julia interface docs
+https://docs.julialang.org/en/v1/manual/interfaces/
 
 Required methods		Brief description
 iterate(iter)		        Returns either a tuple of the first item and initial state or nothing if empty
@@ -24,35 +25,6 @@ EltypeUnknown()	(none)
 =#
 
 # :size demonstrates an interface condition that instead of return a Bool,
-function test_iterator_size(x)
-    sizetrait = Base.IteratorSize(typeof(x))
-    if sizetrait isa Base.HasLength
-        length(x) isa Integer
-    elseif sizetrait isa Base.HasShape
-        length(x) isa Integer &&
-        size(x) isa NTuple{<:Any,<:Integer} &&
-        length(size(x)) == typeof(sizetrait).parameters[1] &&
-        length(x) == prod(size(x))
-    elseif sizetrait isa Base.IsInfinite
-        return true
-    elseif sizetrait isa Base.SizeUnknown
-        return true
-    else
-        error("IteratorSize returns $sizetrait, allowed options are: `HasLength`, `HasLength`, `IsInfinite`, `SizeUnknown`")
-    end
-end
-
-function test_iterator_eltype(x)
-    eltypetrait = Base.IteratorEltype(x)
-    if eltypetrait isa Base.HasEltype
-        x1, _ = iterate(x)
-        typeof(first(x)) <: eltype(x)
-    elseif eltypetrait isa Base.EltypeUnknown
-        true
-    else
-        error("IteratorEltype(x) returns $eltypetrait, allowed options are `HasEltype` or `EltypeUnknown`")
-    end
-end
 
 # `Iterators.reverse` gives reverse iteration
 
@@ -68,8 +40,39 @@ end
             x -> iterate(x, last(iterate(x))) isa Tuple,
         ),
         isiterable = x -> Base.isiterable(typeof(x)),
-        size = test_iterator_size,
-        eltype = test_iterator_eltype,
+        eltype = x -> begin
+            eltypetrait = Base.IteratorEltype(x)
+            if eltypetrait isa Base.HasEltype
+                return "values of `x` are `<: eltype(x)`" => x -> typeof(first(x)) <: eltype(x)
+            elseif eltypetrait isa Base.EltypeUnknown
+                return true
+            else
+                error("IteratorEltype(x) returns $eltypetrait, allowed options are `HasEltype` or `EltypeUnknown`")
+            end
+        end,
+        size = x -> begin
+            sizetrait = Base.IteratorSize(typeof(x))
+            if sizetrait isa Base.HasLength
+                return "`length(x)` returns an `Integer`" => x -> length(x) isa Integer
+            elseif sizetrait isa Base.HasShape
+                # Return more functions to test 
+                return (
+                    "`length(x)` returns an `Int`" => x -> length(x) isa Integer,
+                    "`size(x)` returns a `Tuple` of `Integer`" => 
+                        x -> size(x) isa NTuple{<:Any,<:Integer},
+                    "`size(x)` matches the type parameter of `HasShape`" =>
+                        x -> length(size(x)) == typeof(sizetrait).parameters[1],
+                    "`length(x)` is the product of size(x)" =>
+                        x -> length(x) == prod(size(x)),
+                 )
+            elseif sizetrait isa Base.IsInfinite
+                return true
+            elseif sizetrait isa Base.SizeUnknown
+                return true
+            else
+                error("IteratorSize returns $sizetrait, allowed options are: `HasLength`, `HasLength`, `IsInfinite`, `SizeUnknown`")
+            end
+        end,
         in = x -> first(x) in x,
     ),
     # Optional conditions. These should be specified in the
@@ -78,9 +81,19 @@ end
         reverse = x -> collect(Iterators.reverse(x)) == reverse(collect(x)),
         # TODO: move this to collections?
         indexing = (
-             x -> firstindex(x) isa Integer,
-             x -> lastindex(x) isa Integer,
-             x -> getindex(x, firstindex(x)) == first(iterate(x)),
+             "can call firstindex" => x -> firstindex(x) isa Integer,
+             "can call lastindex" => x -> lastindex(x) isa Integer,
+             "can call getindex" => x -> getindex(x, firstindex(x)) == first(iterate(x)),
+             "getindex matches iteration order" => x -> begin
+                 itr = iterate(x)
+                 i = firstindex(x)
+                 while !isnothing(itr)
+                     getindex(x, i) == itr[1] || return false
+                     itr = iterate(x, itr[2])
+                     i += 1
+                 end
+                 return true
+             end,
         ),
     )
 ) "An interface for Base Julia iteration"

--- a/BaseInterfaces/src/iteration.jl
+++ b/BaseInterfaces/src/iteration.jl
@@ -75,6 +75,7 @@ test_reverse(x) = collect(Iterators.reverse(x)) == reverse(collect(x))
     # that implement the interface.
     mandatory = (
         iterate = test_iterate,
+        isiterable = x -> Base.isiterable(typeof(x)),
         size = test_iterator_size,
         eltype = test_iterator_eltype,
     ),

--- a/BaseInterfaces/src/iteration.jl
+++ b/BaseInterfaces/src/iteration.jl
@@ -31,7 +31,7 @@ function test_iterate(x)
 end
 
 # :size demonstrates an interface condition that instead of return a Bool,
-function test_size(x)
+function test_iterator_size(x)
     sizetrait = Base.IteratorSize(typeof(x))
     if sizetrait isa Base.HasLength
         length(x) isa Integer
@@ -49,9 +49,10 @@ function test_size(x)
     end
 end
 
-function test_eltype(x)
+function test_iterator_eltype(x)
     eltypetrait = Base.IteratorEltype(x) 
     if eltypetrait isa Base.HasEltype 
+        x1, _ = iterate(x) 
         typeof(first(x)) <: eltype(x) 
     elseif eltypetrait isa Base.EltypeUnknown 
         true
@@ -60,11 +61,6 @@ function test_eltype(x)
     end
 end
 
-#=
-:indexing returns three condition functions.
-We force the implementation of `firstindex` and `lastindex`
-Or it is hard to test `getindex` generically
-=#
 function test_indexing(x)
     firstindex(x) isa Integer &&
     lastindex(x) isa Integer &&
@@ -79,8 +75,8 @@ test_reverse(x) = collect(Iterators.reverse(x)) == reverse(collect(x))
     # that implement the interface.
     mandatory = (
         iterate = test_iterate,
-        size = test_size,
-        eltype = test_eltype,
+        size = test_iterator_size,
+        eltype = test_iterator_eltype,
     ),
     # Optional conditions. These should be specified in the
     # interface type if an object implements them: IterationInterface{(:reverse,:indexing)}
@@ -88,4 +84,4 @@ test_reverse(x) = collect(Iterators.reverse(x)) == reverse(collect(x))
         reverse = test_reverse,
         indexing = test_indexing,
     )
-)
+) "An interface for Base Julia iteration"

--- a/BaseInterfaces/src/iteration.jl
+++ b/BaseInterfaces/src/iteration.jl
@@ -70,7 +70,7 @@ end
 # `Iterators.reverse` gives reverse iteration 
 test_reverse(x) = collect(Iterators.reverse(x)) == reverse(collect(x))
 
-@interface IterationInterface (
+@interface IterationInterface Any (
     # Mandatory conditions: these must be met by all types
     # that implement the interface.
     mandatory = (

--- a/BaseInterfaces/src/set.jl
+++ b/BaseInterfaces/src/set.jl
@@ -2,8 +2,13 @@
 
 # Requirements for AbstractSet subtypes:
 
+struct SetTestVal
+    x::Int
+end
+
 set_components = (;
     mandatory = (;
+        isempty = "defines `isempty` and testdata is not empty" => !isempty,
         eltype = "elements eltype of set `s` are subtypes of `eltype(s)`" => s -> typeof(first(iterate(s))) <: eltype(s),
         length = "set defines length and test object has length larger than zero" => s -> length(s) isa Int && length(s) > 0,
         iteration = "follows the IterationInterface" => x -> Interfaces.test(IterationInterface, x; show=false),
@@ -12,48 +17,48 @@ set_components = (;
         end,
     ),
     optional = (;
-        copy = s -> begin
-            s1 = copy(s) 
-            s1 !== s && s1 isa typeof(s) && collect(s) == collect(s1)
-        end,
-        empty = "returns a empty set able to hold elements of type U" => s -> begin
-            s1 = Base.empty(s)
-            eltype(s1) == eltype(s) || return false
-            s1 = Base.empty(s, Int)
-            eltype(s1) == Int || return false
-        end,
-        emptymutable = "returns a empty set able to hold elements of type U" => s -> begin
-            s1 = Base.empty(s)
-            s1 isa typeof(s)
-            eltype(s1) == eltype(s) || return false
-            s1 = Base.empty(s, Int)
-            eltype(s1) == Int || return false
-        end,
-        hasfastin = s -> Base.hasfastin(s) isa Bool,
-        setdiff = s -> begin
-            sd = setdiff(s, collect(s))
-            typeof(sd) == typeof(s) && length(sd) == 0
-        end,
-        intersect = s -> intersect(s, s) == s, # TODO
-        union = s -> union(s, s) == s, # TODO
-        empty! =  "empty! removes all elements from the set" => s -> length(empty!(s)) == 0,
-        delete! = "delete! removes element valued x of the set" => s -> begin
-            x = first(iterate(s))
-            !in(delete!(s, x), x)
-        end,
-        push! = "push! adds element x to the set" => s -> begin
+        copy = "creates an identical object with the same values, that is not the same object" => 
+            s -> (s1 = copy(s); s1 !== s && s1 isa typeof(s) && collect(s) == collect(s1)),
+        empty = (
+            "returns an empty set able to hold elements of type U" => 
+                s -> (s1 = Base.empty(s); isempty(s1) && eltype(s1) == eltype(s)),
+            "returns an empty set able to hold elements of arbitrary types" => 
+                s -> (s1 = Base.empty(s, SetTestVal); isempty(s1) && eltype(s1) == SetTestVal),
+        ),
+        emptymutable = x -> true, # TODO
+        hasfastin = "`hasfastin` returns a `Bool`" => s -> Base.hasfastin(s) isa Bool,
+        setdiff = (
+            "setdiff with itself is an empty set of the same type" => s -> begin
+                sd = setdiff(s, collect(s))
+                sd isa typeof(s) && isempty(sd)
+            end,
+            "setdiff with an empty set is equal to itself" => s -> begin
+                sd = setdiff(s, collect(empty(s)))
+                sd isa typeof(s) && sd == s
+            end,
+        ),
+        intersect = (
+            "`intersect` of set with itself is itself" => s -> intersect(s, s) == s,
+            "`intersect` of set with an empty set is an empty set" => s -> intersect(s, empty(s)) == empty(s),
+        ),
+        union = (
+            "union of a set with itself equals itself" => s -> union(s, s) == s,
+            "union of a set an empty set equals itself" => s -> union(s, empty(s)) == s,
+            # TODO how to cleanly get union with another set..
+        ),
+        empty! =  "empty! removes all elements from the set" => isempty ∘ empty!,
+        delete! = "delete! removes element valued x of the set" => 
+            s -> (x = first(iterate(s)); !in(delete!(s, x), x)),
+        push! = "push! adds an element to the set" => s -> begin
             # TODO do this without delete!
             x = first(iterate(s))
             delete!(s, x)
             push!(s, x)
             in(x, s)
         end,
-        copymutable = s -> begin
-            s1 = Base.copymutable(s)
-            s1 isa typeof(s) && s1 !== s
-        end,
+        copymutable = s -> (s1 = Base.copymutable(s); s1 isa typeof(s) && s1 !== s),
         # TODO is there anything we can actually test here?
-        sizehint = s -> (sizehint!(s, 10); true),
+        sizehint! = "can set a size hint" => s -> (sizehint!(s, 10); true),
     )
 )
 

--- a/BaseInterfaces/src/set.jl
+++ b/BaseInterfaces/src/set.jl
@@ -2,59 +2,60 @@
 
 # Requirements for AbstractSet subtypes:
 
-mandatory = (
-    type = s -> s isa AbstractSet,
-    eltype = "elements eltype of set `s` are subtypes of `eltype(s)`" => s -> typeof(first(iterate(s))) <: eltype(s),
-    length = "set defines length and test object has length larger than zero" => s -> length(s) isa Int && length(s) > 0,
-    iteration = "follows the IterationInterface" => x -> Interfaces.test(IterationInterface, x; show=false),
-    copy = s -> begin
-        s1 = copy(s) 
-        s1 !== s && s1 isa typeof(s) && collect(s) == collect(s1)
-    end,
-    in = "`in` is true for elements in set" => s -> begin
-        all(x -> in(x, s), s)
-    end,
-)
-
-optional = (
-    empty = "returns a empty set able to hold elements of type U" => s -> begin
-        s1 = Base.empty(s)
-        eltype(s1) == eltype(s) || return false
-        s1 = Base.empty(s, Int)
-        eltype(s1) == Int || return false
-    end,
-    emptymutable = "returns a empty set able to hold elements of type U" => s -> begin
-        s1 = Base.empty(s)
-        s1 isa typeof(s)
-        eltype(s1) == eltype(s) || return false
-        s1 = Base.empty(s, Int)
-        eltype(s1) == Int || return false
-    end,
-    hasfastin = s -> Base.hasfastin(s) isa Bool,
-    setdiff = s -> begin
-        sd = setdiff(s, collect(s))
-        typeof(sd) == typeof(s) && length(sd) == 0
-    end,
-    intersect = s -> intesect(s, itr),
-    union = s -> union(s, itr),
-    mutable = (
-        "empty! removes all elements from the set" => s -> empty!(s),
-        "delete! removes element valued x of the set" => s -> begin
+set_components = (;
+    mandatory = (;
+        type = s -> s isa AbstractSet,
+        eltype = "elements eltype of set `s` are subtypes of `eltype(s)`" => s -> typeof(first(iterate(s))) <: eltype(s),
+        length = "set defines length and test object has length larger than zero" => s -> length(s) isa Int && length(s) > 0,
+        iteration = "follows the IterationInterface" => x -> Interfaces.test(IterationInterface, x; show=false),
+        in = "`in` is true for elements in set" => s -> begin
+            all(x -> in(x, s), s)
+        end,
+    ),
+    optional = (;
+        copy = s -> begin
+            s1 = copy(s) 
+            s1 !== s && s1 isa typeof(s) && collect(s) == collect(s1)
+        end,
+        empty = "returns a empty set able to hold elements of type U" => s -> begin
+            s1 = Base.empty(s)
+            eltype(s1) == eltype(s) || return false
+            s1 = Base.empty(s, Int)
+            eltype(s1) == Int || return false
+        end,
+        emptymutable = "returns a empty set able to hold elements of type U" => s -> begin
+            s1 = Base.empty(s)
+            s1 isa typeof(s)
+            eltype(s1) == eltype(s) || return false
+            s1 = Base.empty(s, Int)
+            eltype(s1) == Int || return false
+        end,
+        hasfastin = s -> Base.hasfastin(s) isa Bool,
+        setdiff = s -> begin
+            sd = setdiff(s, collect(s))
+            typeof(sd) == typeof(s) && length(sd) == 0
+        end,
+        intersect = s -> intersect(s, s) == s, # TODO
+        union = s -> union(s, s) == s, # TODO
+        empty! =  "empty! removes all elements from the set" => s -> length(empty!(s)) == 0,
+        delete! = "delete! removes element valued x of the set" => s -> begin
             x = first(iterate(s))
             !in(delete!(s, x), x)
         end,
-        "push! adds element x to the set" => s -> begin
+        push! = "push! adds element x to the set" => s -> begin
+            # TODO do this without delete!
             x = first(iterate(s))
             delete!(s, x)
             push!(s, x)
-            in(s, x)
+            in(x, s)
         end,
-    ),
-    coppymutable = s -> begin
-        s1 = Base.copymutable(s)
-        s1 isa typeof(s) && s1 !== s
-    end,
-    sizehint = s -> (sizehint!(s, n); true),
+        copymutable = s -> begin
+            s1 = Base.copymutable(s)
+            s1 isa typeof(s) && s1 !== s
+        end,
+        # TODO is there anything we can actually test here?
+        sizehint = s -> (sizehint!(s, 10); true),
+    )
 )
 
-@interface SetInterface (; mandatory, optional) "The `AbstractSet` interface"
+@interface SetInterface set_components "The `AbstractSet` interface"

--- a/BaseInterfaces/src/set.jl
+++ b/BaseInterfaces/src/set.jl
@@ -3,6 +3,7 @@
 # Requirements for AbstractSet subtypes:
 
 mandatory = (
+    type = s -> s isa AbstractSet,
     eltype = "elements eltype of set `s` are subtypes of `eltype(s)`" => s -> typeof(first(iterate(s))) <: eltype(s),
     length = "set defines length and test object has length larger than zero" => s -> length(s) isa Int && length(s) > 0,
     iteration = "follows the IterationInterface" => x -> Interfaces.test(IterationInterface, x),

--- a/BaseInterfaces/src/set.jl
+++ b/BaseInterfaces/src/set.jl
@@ -11,10 +11,8 @@ set_components = (;
         isempty = "defines `isempty` and testdata is not empty" => !isempty,
         eltype = "elements eltype of set `s` are subtypes of `eltype(s)`" => s -> typeof(first(iterate(s))) <: eltype(s),
         length = "set defines length and test object has length larger than zero" => s -> length(s) isa Int && length(s) > 0,
-        iteration = "follows the IterationInterface" => x -> Interfaces.test(IterationInterface, x; show=false),
-        in = "`in` is true for elements in set" => s -> begin
-            all(x -> in(x, s), s)
-        end,
+        iteration = "follows the IterationInterface" => s -> Interfaces.test(IterationInterface, s; show=false),
+        in = "`in` is true for elements in set" => s -> all(x -> in(x, s), s),
     ),
     optional = (;
         copy = "creates an identical object with the same values, that is not the same object" => 
@@ -25,7 +23,6 @@ set_components = (;
             "returns an empty set able to hold elements of arbitrary types" => 
                 s -> (s1 = Base.empty(s, SetTestVal); isempty(s1) && eltype(s1) == SetTestVal),
         ),
-        emptymutable = x -> true, # TODO
         hasfastin = "`hasfastin` returns a `Bool`" => s -> Base.hasfastin(s) isa Bool,
         setdiff = (
             "setdiff with itself is an empty set of the same type" => s -> begin
@@ -38,13 +35,22 @@ set_components = (;
             end,
         ),
         intersect = (
+            # TODO how to cleanly get the intersect with another non-empty set
             "`intersect` of set with itself is itself" => s -> intersect(s, s) == s,
             "`intersect` of set with an empty set is an empty set" => s -> intersect(s, empty(s)) == empty(s),
         ),
         union = (
+            # TODO how to cleanly get the union with another non-empty set
             "union of a set with itself equals itself" => s -> union(s, s) == s,
             "union of a set an empty set equals itself" => s -> union(s, empty(s)) == s,
-            # TODO how to cleanly get union with another set..
+        ),
+        copymutable = "creates an identical mutable object with the same values, that is not the same object" => 
+            s -> (s1 = Base.copymutable(s); s1 !== s && s1 isa typeof(s) && collect(s) == collect(s1)),
+        emptymutable = (
+            "returns an empty set able to hold elements of type U" => 
+                s -> (s1 = Base.emptymutable(s); isempty(s1) && eltype(s1) == eltype(s)),
+            "returns an empty set able to hold elements of arbitrary types" => 
+                s -> (s1 = Base.emptymutable(s, SetTestVal); isempty(s1) && eltype(s1) == SetTestVal),
         ),
         empty! =  "empty! removes all elements from the set" => isempty ∘ empty!,
         delete! = "delete! removes element valued x of the set" => 
@@ -56,8 +62,7 @@ set_components = (;
             push!(s, x)
             in(x, s)
         end,
-        copymutable = s -> (s1 = Base.copymutable(s); s1 isa typeof(s) && s1 !== s),
-        # TODO is there anything we can actually test here?
+        # No real way to test this does anything
         sizehint! = "can set a size hint" => s -> (sizehint!(s, 10); true),
     )
 )

--- a/BaseInterfaces/src/set.jl
+++ b/BaseInterfaces/src/set.jl
@@ -6,7 +6,7 @@ mandatory = (
     type = s -> s isa AbstractSet,
     eltype = "elements eltype of set `s` are subtypes of `eltype(s)`" => s -> typeof(first(iterate(s))) <: eltype(s),
     length = "set defines length and test object has length larger than zero" => s -> length(s) isa Int && length(s) > 0,
-    iteration = "follows the IterationInterface" => x -> Interfaces.test(IterationInterface, x),
+    iteration = "follows the IterationInterface" => x -> Interfaces.test(IterationInterface, x; show=false),
     copy = s -> begin
         s1 = copy(s) 
         s1 !== s && s1 isa typeof(s) && collect(s) == collect(s1)

--- a/BaseInterfaces/src/set.jl
+++ b/BaseInterfaces/src/set.jl
@@ -1,0 +1,59 @@
+# See https://github.com/JuliaLang/julia/issues/34677
+
+# Requirements for AbstractSet subtypes:
+
+mandatory = (
+    eltype = "elements eltype of set `s` are subtypes of `eltype(s)`" => s -> typeof(first(iterate(s))) <: eltype(s),
+    length = "set defines length and test object has length larger than zero" => s -> length(s) isa Int && length(s) > 0,
+    iteration = "follows the IterationInterface" => x -> Interfaces.test(IterationInterface, x),
+    copy = s -> begin
+        s1 = copy(s) 
+        s1 !== s && s1 isa typeof(s) && collect(s) == collect(s1)
+    end,
+    in = "`in` is true for elements in set" => s -> begin
+        all(x -> in(x, s), s)
+    end,
+)
+
+optional = (
+    empty = "returns a empty set able to hold elements of type U" => s -> begin
+        s1 = Base.empty(s)
+        eltype(s1) == eltype(s) || return false
+        s1 = Base.empty(s, Int)
+        eltype(s1) == Int || return false
+    end,
+    emptymutable = "returns a empty set able to hold elements of type U" => s -> begin
+        s1 = Base.empty(s)
+        s1 isa typeof(s)
+        eltype(s1) == eltype(s) || return false
+        s1 = Base.empty(s, Int)
+        eltype(s1) == Int || return false
+    end,
+    hasfastin = s -> Base.hasfastin(s) isa Bool,
+    setdiff = s -> begin
+        sd = setdiff(s, collect(s))
+        typeof(sd) == typeof(s) && length(sd) == 0
+    end,
+    intersect = s -> intesect(s, itr),
+    union = s -> union(s, itr),
+    mutable = (
+        "empty! removes all elements from the set" => s -> empty!(s),
+        "delete! removes element valued x of the set" => s -> begin
+            x = first(iterate(s))
+            !in(delete!(s, x), x)
+        end,
+        "push! adds element x to the set" => s -> begin
+            x = first(iterate(s))
+            delete!(s, x)
+            push!(s, x)
+            in(s, x)
+        end,
+    ),
+    coppymutable = s -> begin
+        s1 = Base.copymutable(s)
+        s1 isa typeof(s) && s1 !== s
+    end,
+    sizehint = s -> (sizehint!(s, n); true),
+)
+
+@interface SetInterface (; mandatory, optional) "The `AbstractSet` interface"

--- a/BaseInterfaces/src/set.jl
+++ b/BaseInterfaces/src/set.jl
@@ -4,7 +4,6 @@
 
 set_components = (;
     mandatory = (;
-        type = s -> s isa AbstractSet,
         eltype = "elements eltype of set `s` are subtypes of `eltype(s)`" => s -> typeof(first(iterate(s))) <: eltype(s),
         length = "set defines length and test object has length larger than zero" => s -> length(s) isa Int && length(s) > 0,
         iteration = "follows the IterationInterface" => x -> Interfaces.test(IterationInterface, x; show=false),
@@ -58,4 +57,4 @@ set_components = (;
     )
 )
 
-@interface SetInterface set_components "The `AbstractSet` interface"
+@interface SetInterface AbstractSet set_components "The `AbstractSet` interface"

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -28,7 +28,7 @@ end
     @test Interfaces.test(DictInterface, IdDict, [Arguments(d=IdDict(:a => 1, :b => 2), k=:c, v=3)])
     @test Interfaces.test(DictInterface, Base.EnvDict, [Arguments(d=Base.EnvDict())])
     @test Interfaces.test(DictInterface, Base.ImmutableDict, [Arguments(d=Base.ImmutableDict(:a => 1, :b => 2))])
-    @test Interfaces.test(DictInterface, Base.Pairs, [Arguments(d=Base.pairs((a = 1, b = 2)))])
+    # @test Interfaces.test(DictInterface, Base.Pairs, [Arguments(d=Base.pairs((a = 1, b = 2)))])
     @test Interfaces.test(DictInterface, Test.GenericDict, [Arguments(d=Test.GenericDict(Dict(:a => 1, :b => 2)), k=:c, v=3)])
     a = Ref(1); b = Ref(2)
     @test Interfaces.test(DictInterface, WeakKeyDict, [Arguments(d= d = WeakKeyDict(a => 1, b => 2), k=Ref(3), v=3)])

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -34,7 +34,7 @@ end
     @test Interfaces.test(DictInterface, Test.GenericDict, [Arguments(d=Test.GenericDict(Dict(:a => 1, :b => 2)), k=:c, v=3)])
     GC.enable(false) # Avoid segfaults from garbage collection of WeakKeyDict keys
     a = Ref(1); b = Ref(2); k=Ref(3)
-    @test Interfaces.test(DictInterface, WeakKeyDict, [Arguments(d=WeakKeyDict(a => 1, b => 2), k, v=3)])
+    @test Interfaces.test(DictInterface, WeakKeyDict, [Arguments(; d=WeakKeyDict(a => 1, b => 2), k, v=3)])
     GC.enable(true)
 end
 

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -25,4 +25,5 @@ end
 
 @testset "SetInterface" begin
     @test Interfaces.test(SetInterface, Set, [Set((1, 2))])
+    @test Interfaces.test(SetInterface, BitSet, [BitSet((1, 2))])
 end

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -28,10 +28,14 @@ end
     @test Interfaces.test(DictInterface, IdDict, [Arguments(d=IdDict(:a => 1, :b => 2), k=:c, v=3)])
     @test Interfaces.test(DictInterface, Base.EnvDict, [Arguments(d=Base.EnvDict())])
     @test Interfaces.test(DictInterface, Base.ImmutableDict, [Arguments(d=Base.ImmutableDict(:a => 1, :b => 2))])
-    # @test Interfaces.test(DictInterface, Base.Pairs, [Arguments(d=Base.pairs((a = 1, b = 2)))])
+    @static if VERSION >= v"1.9.0"
+        @test Interfaces.test(DictInterface, Base.Pairs, [Arguments(d=Base.pairs((a = 1, b = 2)))])
+    end
     @test Interfaces.test(DictInterface, Test.GenericDict, [Arguments(d=Test.GenericDict(Dict(:a => 1, :b => 2)), k=:c, v=3)])
-    a = Ref(1); b = Ref(2)
-    @test Interfaces.test(DictInterface, WeakKeyDict, [Arguments(d= d = WeakKeyDict(a => 1, b => 2), k=Ref(3), v=3)])
+    GC.enable(false) # Avoid segfaults from garbage collection of WeakKeyDict keys
+    a = Ref(1); b = Ref(2); k=Ref(3)
+    @test Interfaces.test(DictInterface, WeakKeyDict, [Arguments(d=WeakKeyDict(a => 1, b => 2), k, v=3)])
+    GC.enable(true)
 end
 
 @testset "IterationInterface" begin
@@ -47,5 +51,6 @@ end
     @test Interfaces.test(SetInterface, BitSet, [BitSet((1, 2))])
     @test Interfaces.test(SetInterface, Base.KeySet, [Base.KeySet(Dict(:a=>1, :b=>2))])
     @test Interfaces.test(SetInterface, Test.GenericSet, [Test.GenericSet(Set((1, 2)))])
-    # @test Interfaces.test(SetInterface, Base.IdSet, ?) 
+    s = Base.IdSet(); push!(s, "a"); push!(s, "b")
+    @test Interfaces.test(SetInterface, Base.IdSet, [s]) 
 end

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -2,10 +2,27 @@ using BaseInterfaces
 using Interfaces
 using Test
 
-@testset "BaseInterfaces.jl" begin
+@testset "ArrayInterface" begin
+    @test Interfaces.test(ArrayInterface, Array, [[1, 2]])
+    @test Interfaces.test(ArrayInterface, SubArray, [view([1, 2], 1:2)])
+end
+
+@testset "DictInterface" begin
+    @test Interfaces.test(DictInterface, Dict, [Arguments(d=Dict(:a => 1, :b => 2), k=:c, v=3)])
+    @test Interfaces.test(DictInterface, IdDict, [Arguments(d=IdDict(:a => 1, :b => 2), k=:c, v=3)])
+    @test Interfaces.test(DictInterface, Base.EnvDict, [Arguments(d=Base.EnvDict())])
+    @test Interfaces.test(DictInterface, Base.ImmutableDict, [Arguments(d=Base.ImmutableDict(:a => 1, :b => 2))])
+    @test Interfaces.test(DictInterface, Base.Pairs, [Arguments(d=Base.pairs((a = 1, b = 2)))])
+end
+
+@testset "IterationInterface" begin
     @test Interfaces.test(IterationInterface, UnitRange, [1:5, -2:2])
     @test Interfaces.test(IterationInterface, StepRange, [1:2:10, 20:-10:-20])
     @test Interfaces.test(IterationInterface, Array, [[1, 2, 3, 4], [:a :b; :c :d]])
     @test Interfaces.test(IterationInterface, Base.Generator, [(i for i in 1:5), (i for i in 1:5)])
     @test Interfaces.test(IterationInterface, Tuple, [(1, 2, 3, 4)])
+end
+
+@testset "SetInterface" begin
+    @test Interfaces.test(SetInterface, Set, [Set((1, 2))])
 end

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -2,7 +2,7 @@ using BaseInterfaces
 using Interfaces
 using Test
 
-@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint)} Test.GenericSet
+@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint!)} Test.GenericSet
 @implements DictInterface Test.GenericDict
 
 @testset "ArrayInterface" begin

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -2,9 +2,25 @@ using BaseInterfaces
 using Interfaces
 using Test
 
+@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint)} Test.GenericSet
+@implements DictInterface Test.GenericDict
+
 @testset "ArrayInterface" begin
-    @test Interfaces.test(ArrayInterface, Array, [[1, 2]])
-    @test Interfaces.test(ArrayInterface, SubArray, [view([1, 2], 1:2)])
+    @test Interfaces.test(ArrayInterface, Array, [[3, 2], ['a' 'b'; 'n' 'm']])
+    @test Interfaces.test(ArrayInterface, BitArray, [BitArray([false true; true false])])
+    @test Interfaces.test(ArrayInterface, SubArray, [view([7, 2], 1:2)])
+    @test Interfaces.test(ArrayInterface, PermutedDimsArray, [PermutedDimsArray([7 2], (2, 1))])
+    @test Interfaces.test(ArrayInterface, Base.ReshapedArray, [reshape(view([7, 2], 1:2), 2, 1)])
+    @test Interfaces.test(ArrayInterface, UnitRange, [2:10])
+    @test Interfaces.test(ArrayInterface, StepRange, [2:1:10])
+    @test Interfaces.test(ArrayInterface, Base.OneTo, [Base.OneTo(10)])
+    @test Interfaces.test(ArrayInterface, Base.Slice, [Base.Slice(100:150)])
+    @test Interfaces.test(ArrayInterface, Base.IdentityUnitRange, [Base.IdentityUnitRange(100:150)])
+    @test Interfaces.test(ArrayInterface, Base.CodeUnits, [codeunits("abcde")])
+    # No `getindex` defined for LogicalIndex
+    @test_broken Interfaces.test(ArrayInterface, Base.LogicalIndex, [to_indices([1, 2, 3], ([false, true, true],))[1]])
+
+    # TODO test LinearAlgebra arrays and SparseArrays
 end
 
 @testset "DictInterface" begin
@@ -13,6 +29,9 @@ end
     @test Interfaces.test(DictInterface, Base.EnvDict, [Arguments(d=Base.EnvDict())])
     @test Interfaces.test(DictInterface, Base.ImmutableDict, [Arguments(d=Base.ImmutableDict(:a => 1, :b => 2))])
     @test Interfaces.test(DictInterface, Base.Pairs, [Arguments(d=Base.pairs((a = 1, b = 2)))])
+    @test Interfaces.test(DictInterface, Test.GenericDict, [Arguments(d=Test.GenericDict(Dict(:a => 1, :b => 2)), k=:c, v=3)])
+    a = Ref(1); b = Ref(2)
+    @test Interfaces.test(DictInterface, WeakKeyDict, [Arguments(d= d = WeakKeyDict(a => 1, b => 2), k=Ref(3), v=3)])
 end
 
 @testset "IterationInterface" begin
@@ -26,4 +45,7 @@ end
 @testset "SetInterface" begin
     @test Interfaces.test(SetInterface, Set, [Set((1, 2))])
     @test Interfaces.test(SetInterface, BitSet, [BitSet((1, 2))])
+    @test Interfaces.test(SetInterface, Base.KeySet, [Base.KeySet(Dict(:a=>1, :b=>2))])
+    @test Interfaces.test(SetInterface, Test.GenericSet, [Test.GenericSet(Set((1, 2)))])
+    # @test Interfaces.test(SetInterface, Base.IdSet, ?) 
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -48,6 +48,7 @@ makedocs(;
         "Home" => "index.md",
         "Examples" => ["Basic" => "basic.md", "Advanced" => "advanced.md"],
         "API reference" => "api.md",
+        "BaseInterfaces.jl reference" => "baseinterfaces.md",
     ],
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,6 @@
 using Documenter
 using Interfaces
+using BaseInterfaces
 using Literate
 
 DocMeta.setdocmeta!(Interfaces, :DocTestSetup, :(using Interfaces); recursive=true)
@@ -34,7 +35,7 @@ Literate.markdown(
 )
 
 makedocs(;
-    modules=[Interfaces],
+    modules=[Interfaces, BaseInterfaces],
     authors="Rafael Schouten <rafaelschouten@gmail.com>",
     sitename="Interfaces.jl",
     format=Documenter.HTML(;

--- a/docs/src/baseinterfaces.jl
+++ b/docs/src/baseinterfaces.jl
@@ -1,0 +1,12 @@
+# BaseInterfaces reference
+
+## Docstrings
+
+```@autodocs
+Modules = [BaseInterfaces]
+```
+
+## Index
+
+```@index
+```

--- a/docs/src/baseinterfaces.md
+++ b/docs/src/baseinterfaces.md
@@ -1,0 +1,12 @@
+# BaseInterfaces reference
+
+## Docstrings
+
+```@autodocs
+Modules = [BaseInterfaces]
+```
+
+## Index
+
+```@index
+```

--- a/src/implements.jl
+++ b/src/implements.jl
@@ -51,6 +51,10 @@ function _implements_inner(interface, objtype; show=false)
     if interface isa Expr && interface.head == :curly
         interfacetype = interface.args[1]    
         optional_keys = interface.args[2]
+        # Allow a single Symbol instead of a Tuple
+        if optional_keys isa QuoteNode
+            optional_keys = (optional_keys.value,)
+        end
     else
         interfacetype = interface
         optional_keys = ()

--- a/src/test.jl
+++ b/src/test.jl
@@ -99,7 +99,8 @@ function _test(name::Symbol, condition, objs::TestObjectWrapper, i=nothing)
 end
 function _test(name::Symbol, condition, obj, i=nothing)
     try
-        res = condition isa Pair ? condition[2](obj) : condition(obj)
+        obj_copy = deepcopy(obj)
+        res = condition isa Pair ? condition[2](obj_copy) : condition(obj_copy)
         # Allow returning a function or tuple of functions that are tested again
         if res isa Union{Pair,Tuple,Base.Callable}
             return _test(name, res, obj, i)

--- a/src/test.jl
+++ b/src/test.jl
@@ -84,7 +84,9 @@ function _test(T::Type{<:Interface}, O::Type, objs::TestObjectWrapper;
         optional_results = _test(T, optional, objs)
         if show
             _showresults(stdout, mandatory_results, "Mandatory components")
-            _showresults(stdout, optional_results, "Optional components")
+            if !isempty(optional_results)
+                _showresults(stdout, optional_results, "Optional components")
+            end
         end
         return all(_bool(mandatory_results)) && all(_bool(optional_results))
     else
@@ -146,7 +148,7 @@ end
 _showresult(io, key, res) = show(res)
 function _showresult(io, key, pair::Pair)
     desc, res = pair
-    print("\"", desc, "\" ")
+    print(desc, " ")
     _showresult(io, key, res)
 end
 _showresult(io, key, res::Bool) = printstyled(io, res; color=(res ? :green : :red))

--- a/src/test.jl
+++ b/src/test.jl
@@ -4,6 +4,23 @@ struct TestObjectWrapper{O}
     objects::O
 end
 
+struct InterfaceError <: Exception 
+    t::Type
+    name::Symbol
+    num::Union{Nothing,Int}
+    desc::String
+    obj::Any
+    e::Exception
+end
+
+function Base.showerror(io::IO, ie::InterfaceError)
+    (; t, name, num, desc, obj, e) = ie
+    printstyled("InterfaceError: "; color=:red)
+    numstring = isnothing(num) ? "" : " $num"
+    println("test for $t :$name$numstring$desc threw a $(typeof(e)) \n For test object $obj:\n")
+    Base.showerror(io, e)
+end
+
 Base.iterate(tow::TestObjectWrapper, args...) = iterate(tow.objects, args...)
 Base.length(tow::TestObjectWrapper, args...) = length(tow.objects)
 Base.getindex(tow::TestObjectWrapper, i::Int) = getindex(tow.objects, i)
@@ -56,102 +73,107 @@ function _test(T::Type{<:Interface}, O::Type, objs::TestObjectWrapper;
     O <: requiredtype(T) || throw(ArgumentError("$O is not a subtype of $(requiredtype(T))"))  
     check_coherent_types(O, objs)
     if show
-        print("Testing ")
+        print("\nTesting ")
         printstyled(_get_type(T).name.name; color=:blue)
         print(" is implemented for ")
         printstyled(O, "\n"; color=:blue)
     end
     if isnothing(keys)
         optional = NamedTuple{optional_keys(T, O)}(components(T).optional)
-        mandatory_results = _test(components(T).mandatory, objs)
-        optional_results = _test(optional, objs)
+        mandatory_results = _test(T, components(T).mandatory, objs)
+        optional_results = _test(T, optional, objs)
         if show
-            _showresults(mandatory_results, "Mandatory components")
-            _showresults(optional_results, "Optional components")
+            _showresults(stdout, mandatory_results, "Mandatory components")
+            _showresults(stdout, optional_results, "Optional components")
         end
         return all(_bool(mandatory_results)) && all(_bool(optional_results))
     else
         allcomponents = merge(components(T)...)
         optional = NamedTuple{_as_tuple(keys)}(allcomponents)
-        results = _test(optional, objs)
-        show && _showresults(results, "Specified components")
+        results = _test(T, optional, objs)
+        show && _showresults(stdout, results, "Specified components")
         return all(_bool(results))
     end
 end
 
-function _test(tests::NamedTuple{K}, objs::TestObjectWrapper) where K
+function _test(T, tests::NamedTuple{K}, objs::TestObjectWrapper) where K
     map(keys(tests), values(tests)) do k, v
-        _test(k, v, objs)
+        _test(T, k, v, objs)
     end |> NamedTuple{K}
 end
-function _test(name::Symbol, condition::Tuple, objs, i=nothing)
+function _test(T, name::Symbol, condition::Tuple, objs, i=nothing)
     map(condition, ntuple(identity, length(condition))) do c, i
-        _test(name, c, objs, i)
+        _test(T, name, c, objs, i)
     end
 end
-function _test(name::Symbol, condition::Tuple, objs::TestObjectWrapper, i=nothing)
+function _test(T, name::Symbol, condition::Tuple, objs::TestObjectWrapper, i=nothing)
     map(condition, ntuple(identity, length(condition))) do c, i
-        _test(name, c, objs, i)
+        _test(T, name, c, objs, i)
     end
 end
-function _test(name::Symbol, condition, objs::TestObjectWrapper, i=nothing)
-    map(o -> _test(name, condition, o, i), objs.objects)
+function _test(T, name::Symbol, condition, objs::TestObjectWrapper, i=nothing)
+    map(o -> _test(T, name, condition, o, i), objs.objects)
 end
-function _test(name::Symbol, condition, obj, i=nothing)
-    try
-        obj_copy = deepcopy(obj)
-        res = condition isa Pair ? condition[2](obj_copy) : condition(obj_copy)
+function _test(T, name::Symbol, condition, obj, i=nothing)
+    obj_copy = deepcopy(obj)
+    res = try
+        f = condition isa Pair ? condition[2] : condition
+        f(obj_copy)
         # Allow returning a function or tuple of functions that are tested again
-        if res isa Union{Pair,Tuple,Base.Callable}
-            return _test(name, res, obj, i)
-        else
-            return condition isa Pair ? condition[1] => res : res
-        end
     catch e
-        num = isnothing(i) ? "" : ", condition $i"
         desc = condition isa Pair ? string(" \"", condition[1], "\"") : ""
-        @warn "interface test :$name$num$desc failed for test object $obj"
-        rethrow(e)
+        rethrow(InterfaceError(T, name, i, desc, obj, e))
+    end
+
+    if res isa Union{Pair,Tuple,Base.Callable}
+        return _test(T, name, res, obj, i)
+    else
+        return condition isa Pair ? condition[1] => res : res
     end
 end
 
-function _showresults(results::NamedTuple, title::String)
+function _showresults(io::IO, results::NamedTuple, title::String)
     printstyled(title; color=:light_black)
     println()
     foreach(keys(results), results) do k, res
-        print("$k : ")
-        _showresult(k, res)
+        printstyled("$k"; color=:magenta)
+        print(": ")
+        _showresult(io, k, res)
         println()
     end
 end
 
-_showresult(key, res) = show(res)
-function _showresult(key, pair::Pair)
+_showresult(io, key, res) = show(res)
+function _showresult(io, key, pair::Pair)
     desc, res = pair
-    print(desc, ": ")
-    _showresult(key, res)
+    print("\"", desc, "\" ")
+    _showresult(io, key, res)
 end
-_showresult(key, res::Bool) = printstyled(res; color=(res ? :green : :red))
-function _showresult(key, res::AbstractArray)
-    print("[") 
-    _showresult(key, first(res))
+_showresult(io, key, res::Bool) = printstyled(io, res; color=(res ? :green : :red))
+function _showresult(io, key, res::AbstractArray)
+    print(io, "[") 
+    _showresult(io, key, first(res))
     for r in res[2:end]
-        print(", ") 
-        _showresult(key, r) 
+        print(io, ", ") 
+        _showresult(io, key, r) 
     end
-    print("]") 
+    print(io, "]") 
 end
-function _showresult(key, res::AbstractArray{<:Pair})
-    _showresult(key, first(first(res)) => last.(res))
+function _showresult(io, key, res::AbstractArray{<:Pair})
+    _showresult(io, key, first(first(res)) => last.(res))
 end
-function _showresult(key, res::NTuple{<:Any,Bool})
-    _showresult(key, first(res))
-    map(r -> (print(", "); _showresult(key, r)), Base.tail(res))
+function _showresult(io, key, res::NTuple{<:Any,Bool})
+    print(io, "(") 
+    _showresult(io, key, first(res))
+    map(r -> (print(io, ", "); _showresult(io, key, r)), Base.tail(res))
+    print(io, ")") 
 end
-function _showresult(key, res::NTuple{<:Any})
-    _showresult(key, first(res))
+function _showresult(io, key, res::NTuple{<:Any})
+    print(io, "(") 
+    _showresult(io, key, first(res))
     spacer = join([' ' for i in 1:length(string(key)) + 3])
-    map(r -> (print(",\n$spacer"); _showresult(key, r)), Base.tail(res))
+    map(r -> (print(io, ",\n$spacer"); _showresult(io, key, r)), Base.tail(res))
+    print(io, ")") 
 end
 
 _bool(xs::Union{Tuple,NamedTuple,AbstractArray}) = all(map(_bool, xs))

--- a/src/test.jl
+++ b/src/test.jl
@@ -14,10 +14,9 @@ struct InterfaceError <: Exception
 end
 
 function Base.showerror(io::IO, ie::InterfaceError)
-    (; t, name, num, desc, obj, e) = ie
     printstyled("InterfaceError: "; color=:red)
-    numstring = isnothing(num) ? "" : " $num"
-    println("test for $t :$name$numstring$desc threw a $(typeof(e)) \n For test object $obj:\n")
+    numstring = isnothing(ie.num) ? "" : " $(ie.num)"
+    println("test for $(ie.t) :$(ie.name)$(ie.numstring)$(ie.desc) threw a $(typeof(ie.e)) \n For test object $(ie.obj):\n")
     Base.showerror(io, e)
 end
 

--- a/test/advanced.jl
+++ b/test/advanced.jl
@@ -1,4 +1,4 @@
-# # Basic
+# # Advanced
 
 #=
 Here's an example of multi-argument interface using groups.

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -102,10 +102,10 @@ using Test  #src
     @test Interfaces.test(Animals.AnimalInterface, Duck, ducks) == true  #src
     @test Interfaces.test(Animals.AnimalInterface{(:walk,:talk)}, Duck, ducks) == true  #src
     # TODO wrap errors somehow, or just let Invariants.jl handle that.  #src
-    @test_throws MethodError Interfaces.test(Animals.AnimalInterface{:dig}, Duck, ducks)  #src
+    @test_throws Interfaces.InterfaceError Interfaces.test(Animals.AnimalInterface{:dig}, Duck, ducks)  #src
 end  #src
 
 @testset "Chicken" begin  #src
     @test Interfaces.implements(Animals.AnimalInterface{(:walk,:talk)}, Chicken()) == false  #src
-    @test_throws MethodError Interfaces.test(Animals.AnimalInterface{(:walk,:talk)}, Chicken())  #src
+    @test_throws Interfaces.InterfaceError Interfaces.test(Animals.AnimalInterface{(:walk,:talk)}, Chicken())  #src
 end  #src


### PR DESCRIPTION
This PR adds the start of `AbstractSet`, `AbstractDict`, and `AbstractArray` to BaseInterfaces.jl

Hopefully this will end with interface tests that help people write interfaces for these base types and
know they are correct and complete.

@gdalle thoughts or contributions to the cause would be appreciated! 

