### PR TITLE
allow custom module names in macros

### DIFF
--- a/src/implements.jl
+++ b/src/implements.jl
@@ -57,11 +57,11 @@ function _implements_inner(interface, objtype; show=false)
     end
     quote
         # Define a `implements` trait stating that `objtype` implements `interface`
-        Interfaces.implements(::Type{<:$interfacetype}, ::Type{<:$objtype}) = true
-        Interfaces.implements(T::Type{<:$interfacetype{Options}}, O::Type{<:$objtype}) where Options = 
-            Interfaces._all_in(Options, Interfaces.optional_keys(T, O))
+        $Interfaces.implements(::Type{<:$interfacetype}, ::Type{<:$objtype}) = true
+        $Interfaces.implements(T::Type{<:$interfacetype{Options}}, O::Type{<:$objtype}) where Options = 
+            $Interfaces._all_in(Options, $Interfaces.optional_keys(T, O))
         # Define which optional components the object implements
-        Interfaces.optional_keys(::Type{<:$interfacetype}, ::Type{<:$objtype}) = $optional_keys
+        $Interfaces.optional_keys(::Type{<:$interfacetype}, ::Type{<:$objtype}) = $optional_keys
         nothing
     end |> esc
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -56,17 +56,17 @@ description = "A description of the interface"
 macro interface(interface::Symbol, components, description)
     quote
         # Define the interface type (should it be concrete?)
-        abstract type $interface{Components} <: Interfaces.Interface{Components} end
+        abstract type $interface{Components} <: $Interfaces.Interface{Components} end
         # Define the interface component methods
         @assert $components isa NamedTuple{(:mandatory,:optional)}
-        Interfaces.components(::Type{<:$interface}) = $components
+        $Interfaces.components(::Type{<:$interface}) = $components
         @assert $description isa String
-        Interfaces.description(::Type{<:$interface}) = $description
+        $Interfaces.description(::Type{<:$interface}) = $description
         # Generate a docstring for the interface
         let description=$description,
             interfacesym=$(QuoteNode(interface)),
-            m_keys=Interfaces.mandatory_keys($interface),
-            o_keys=Interfaces.optional_keys($interface)
+            m_keys=$Interfaces.mandatory_keys($interface),
+            o_keys=$Interfaces.optional_keys($interface)
             @doc """
                 $("   ") $interfacesym
 


### PR DESCRIPTION
Currently the macros don't work if you do 

```julia
import Interfaces as Ifs
```

This PR fixes that.