### PR TITLE
put test objects in implements and test modules

### DIFF
--- a/BaseInterfaces/src/implementations.jl
+++ b/BaseInterfaces/src/implementations.jl
@@ -17,7 +17,8 @@
 
 @implements DictInterface{:setindex!} Dict [Arguments(d=Dict(:a => 1, :b => 2), k=:c, v=3)]
 @implements DictInterface{:setindex!} IdDict [Arguments(d=IdDict(:a => 1, :b => 2), k=:c, v=3)]
-@implements DictInterface{:setindex!} WeakKeyDict [Arguments(; d=WeakKeyDict(Ref(1) => 1, Ref(2) => 2), k=Ref(3), v=3)]
+# This errors because the ref is garbage collected?
+# @implements DictInterface{:setindex!} WeakKeyDict [Arguments(; d=WeakKeyDict(Ref(1) => 1, Ref(2) => 2), k=Ref(3), v=3)]
 @implements DictInterface Base.EnvDict [Arguments(d=Base.EnvDict())]
 @implements DictInterface Base.ImmutableDict [Arguments(d=Base.ImmutableDict(:a => 1, :b => 2))]
 @static if VERSION >= v"1.9.0"

--- a/BaseInterfaces/src/implementations.jl
+++ b/BaseInterfaces/src/implementations.jl
@@ -1,43 +1,47 @@
 # Some example interface delarations.
 
 # @implements ArrayInterface Base.LogicalIndex # No getindex
-@implements ArrayInterface UnitRange
-@implements ArrayInterface StepRange
-@implements ArrayInterface Base.Slice
-@implements ArrayInterface Base.IdentityUnitRange
-@implements ArrayInterface Base.CodeUnits
-@implements ArrayInterface{(:setindex!,:similar_type,:similar_eltype,:similar_size)} Array
-@implements ArrayInterface{(:setindex!,:similar_type,:similar_size)} BitArray
-@implements ArrayInterface{:setindex!} SubArray
-@implements ArrayInterface{:setindex!} PermutedDimsArray
-@implements ArrayInterface{:setindex!} Base.ReshapedArray
 
-@implements DictInterface{:setindex!} Dict
-@implements DictInterface{:setindex!} IdDict
-@implements DictInterface{:setindex!} WeakKeyDict
-@implements DictInterface Base.EnvDict
-@implements DictInterface Base.ImmutableDict
+
+@implements ArrayInterface UnitRange [2:10]
+@implements ArrayInterface StepRange [2:1:10]
+@implements ArrayInterface Base.OneTo [Base.OneTo(10)]
+@implements ArrayInterface Base.Slice [Base.Slice(100:150)]
+@implements ArrayInterface Base.CodeUnits [codeunits("abcde")]
+@implements ArrayInterface Base.IdentityUnitRange [Base.IdentityUnitRange(100:150)]
+@implements ArrayInterface{(:setindex!,:similar_type,:similar_eltype,:similar_size)} Array [[3, 2], ['a' 'b'; 'n' 'm']]
+@implements ArrayInterface{(:setindex!,:similar_type,:similar_size)} BitArray [BitArray([false true; true false])]
+@implements ArrayInterface{:setindex!} SubArray [view([7, 2], 1:2)]
+@implements ArrayInterface{:setindex!} PermutedDimsArray [PermutedDimsArray([7 2], (2, 1))]
+@implements ArrayInterface{:setindex!} Base.ReshapedArray [reshape(view([7, 2], 1:2), 2, 1)]
+
+@implements DictInterface{:setindex!} Dict [Arguments(d=Dict(:a => 1, :b => 2), k=:c, v=3)]
+@implements DictInterface{:setindex!} IdDict [Arguments(d=IdDict(:a => 1, :b => 2), k=:c, v=3)]
+@implements DictInterface{:setindex!} WeakKeyDict [Arguments(; d=WeakKeyDict(Ref(1) => 1, Ref(2) => 2), k=Ref(3), v=3)]
+@implements DictInterface Base.EnvDict [Arguments(d=Base.EnvDict())]
+@implements DictInterface Base.ImmutableDict [Arguments(d=Base.ImmutableDict(:a => 1, :b => 2))]
 @static if VERSION >= v"1.9.0"
-    @implements DictInterface Base.Pairs
+    @implements DictInterface Base.Pairs [Arguments(d=Base.pairs((a = 1, b = 2)))]
 end
 
-@implements IterationInterface{(:reverse,:indexing)} UnitRange
-@implements IterationInterface{(:reverse,:indexing)} StepRange
-@implements IterationInterface{(:reverse,:indexing)} Array
-@implements IterationInterface{(:reverse,:indexing)} Tuple
-@implements IterationInterface{(:reverse,:indexing)} NamedTuple
-@implements IterationInterface{(:reverse,:indexing)} String
-@implements IterationInterface{(:reverse,:indexing)} Pair
-@implements IterationInterface{(:reverse,:indexing)} Number
-@implements IterationInterface{(:reverse,:indexing)} Base.EachLine
-@implements IterationInterface{(:reverse,)} Base.Generator
-@implements IterationInterface Set
-@implements IterationInterface BitSet
-@implements IterationInterface IdDict
-@implements IterationInterface Dict
-@implements IterationInterface WeakKeyDict
+@implements IterationInterface{(:reverse,:indexing)} UnitRange [1:5, -2:2]
+@implements IterationInterface{(:reverse,:indexing)} StepRange [1:2:10, 20:-10:-20]
+@implements IterationInterface{(:reverse,:indexing)} Array [[1, 2, 3, 4], [:a :b; :c :d]]
+@implements IterationInterface{(:reverse,:indexing)} Tuple [(1, 2, 3, 4)]
+@implements IterationInterface{(:reverse,:indexing)} NamedTuple [(a=1, b=2, c=3, d=4)]
+# @implements IterationInterface{(:reverse,:indexing)} String
+# @implements IterationInterface{(:reverse,:indexing)} Pair
+# @implements IterationInterface{(:reverse,:indexing)} Number
+# @implements IterationInterface{(:reverse,:indexing)} Base.EachLine
+@implements IterationInterface{(:reverse,)} Base.Generator [(i for i in 1:5), (i for i in 1:5)]
+# @implements IterationInterface Set
+# @implements IterationInterface BitSet
+# @implements IterationInterface IdDict
+# @implements IterationInterface Dict
+# @implements IterationInterface WeakKeyDict
 
 # TODO add grouping to reduce the number of options
-@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:union,:empty!,:delete!,:push!,:copymutable,:sizehint!)} Set
-@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:union,:empty!,:delete!,:push!,:copymutable,:sizehint!)} BitSet
-@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint!)} Base.KeySet
+@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:union,:empty!,:delete!,:push!,:copymutable,:sizehint!)} Set [Set((1, 2))]
+@implements SetInterface{(:copy,:empty,:emptymutable,:hasfastin,:setdiff,:intersect,:union,:empty!,:delete!,:push!,:copymutable,:sizehint!)} BitSet [BitSet((1, 2))]
+@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint!)} Base.KeySet [Base.KeySet(Dict(:a=>1, :b=>2))]
+@implements SetInterface{(:empty,:hasfastin,:intersect,:union,:sizehint!)} Base.IdSet (s = Base.IdSet(); push!(s, "a"); push!(s, "b"); [s])

--- a/BaseInterfaces/src/implementations.jl
+++ b/BaseInterfaces/src/implementations.jl
@@ -17,7 +17,7 @@
 
 @implements DictInterface{:setindex!} Dict [Arguments(d=Dict(:a => 1, :b => 2), k=:c, v=3)]
 @implements DictInterface{:setindex!} IdDict [Arguments(d=IdDict(:a => 1, :b => 2), k=:c, v=3)]
-# This errors because the ref is garbage collected?
+# This errors because the ref is garbage collected
 # @implements DictInterface{:setindex!} WeakKeyDict [Arguments(; d=WeakKeyDict(Ref(1) => 1, Ref(2) => 2), k=Ref(3), v=3)]
 @implements DictInterface Base.EnvDict [Arguments(d=Base.EnvDict())]
 @implements DictInterface Base.ImmutableDict [Arguments(d=Base.ImmutableDict(:a => 1, :b => 2))]
@@ -29,12 +29,16 @@ end
 @implements IterationInterface{(:reverse,:indexing)} StepRange [1:2:10, 20:-10:-20]
 @implements IterationInterface{(:reverse,:indexing)} Array [[1, 2, 3, 4], [:a :b; :c :d]]
 @implements IterationInterface{(:reverse,:indexing)} Tuple [(1, 2, 3, 4)]
-@implements IterationInterface{(:reverse,:indexing)} NamedTuple [(a=1, b=2, c=3, d=4)]
+@static if VERSION >= v"1.9.0"
+    @implements IterationInterface{(:reverse,:indexing)} NamedTuple [(a=1, b=2, c=3, d=4)]
+else
+    @implements IterationInterface{:indexing} NamedTuple [(a=1, b=2, c=3, d=4)] # No reverse on 1.6
+end
 # @implements IterationInterface{(:reverse,:indexing)} String
 # @implements IterationInterface{(:reverse,:indexing)} Pair
 # @implements IterationInterface{(:reverse,:indexing)} Number
 # @implements IterationInterface{(:reverse,:indexing)} Base.EachLine
-@implements IterationInterface{(:reverse,)} Base.Generator [(i for i in 1:5), (i for i in 1:5)]
+@implements IterationInterface{:reverse} Base.Generator [(i for i in 1:5), (i for i in 1:5)]
 # @implements IterationInterface Set
 # @implements IterationInterface BitSet
 # @implements IterationInterface IdDict

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -2,55 +2,9 @@ using BaseInterfaces
 using Interfaces
 using Test
 
-@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint!)} Test.GenericSet
-@implements DictInterface Test.GenericDict
+@implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint!)} Test.GenericSet [Test.GenericSet(Set((1, 2)))]
+@implements DictInterface Test.GenericDict [Arguments(d=Test.GenericDict(Dict(:a => 1, :b => 2)), k=:c, v=3)]
 
-@testset "ArrayInterface" begin
-    @test Interfaces.test(ArrayInterface, Array, [[3, 2], ['a' 'b'; 'n' 'm']])
-    @test Interfaces.test(ArrayInterface, BitArray, [BitArray([false true; true false])])
-    @test Interfaces.test(ArrayInterface, SubArray, [view([7, 2], 1:2)])
-    @test Interfaces.test(ArrayInterface, PermutedDimsArray, [PermutedDimsArray([7 2], (2, 1))])
-    @test Interfaces.test(ArrayInterface, Base.ReshapedArray, [reshape(view([7, 2], 1:2), 2, 1)])
-    @test Interfaces.test(ArrayInterface, UnitRange, [2:10])
-    @test Interfaces.test(ArrayInterface, StepRange, [2:1:10])
-    @test Interfaces.test(ArrayInterface, Base.OneTo, [Base.OneTo(10)])
-    @test Interfaces.test(ArrayInterface, Base.Slice, [Base.Slice(100:150)])
-    @test Interfaces.test(ArrayInterface, Base.IdentityUnitRange, [Base.IdentityUnitRange(100:150)])
-    @test Interfaces.test(ArrayInterface, Base.CodeUnits, [codeunits("abcde")])
-    # No `getindex` defined for LogicalIndex
-    @test_broken Interfaces.test(ArrayInterface, Base.LogicalIndex, [to_indices([1, 2, 3], ([false, true, true],))[1]])
+Interfaces.test(BaseInterfaces)
 
-    # TODO test LinearAlgebra arrays and SparseArrays
-end
-
-@testset "DictInterface" begin
-    @test Interfaces.test(DictInterface, Dict, [Arguments(d=Dict(:a => 1, :b => 2), k=:c, v=3)])
-    @test Interfaces.test(DictInterface, IdDict, [Arguments(d=IdDict(:a => 1, :b => 2), k=:c, v=3)])
-    @test Interfaces.test(DictInterface, Base.EnvDict, [Arguments(d=Base.EnvDict())])
-    @test Interfaces.test(DictInterface, Base.ImmutableDict, [Arguments(d=Base.ImmutableDict(:a => 1, :b => 2))])
-    @static if VERSION >= v"1.9.0"
-        @test Interfaces.test(DictInterface, Base.Pairs, [Arguments(d=Base.pairs((a = 1, b = 2)))])
-    end
-    @test Interfaces.test(DictInterface, Test.GenericDict, [Arguments(d=Test.GenericDict(Dict(:a => 1, :b => 2)), k=:c, v=3)])
-    GC.enable(false) # Avoid segfaults from garbage collection of WeakKeyDict keys
-    a = Ref(1); b = Ref(2); k=Ref(3)
-    @test Interfaces.test(DictInterface, WeakKeyDict, [Arguments(; d=WeakKeyDict(a => 1, b => 2), k, v=3)])
-    GC.enable(true)
-end
-
-@testset "IterationInterface" begin
-    @test Interfaces.test(IterationInterface, UnitRange, [1:5, -2:2])
-    @test Interfaces.test(IterationInterface, StepRange, [1:2:10, 20:-10:-20])
-    @test Interfaces.test(IterationInterface, Array, [[1, 2, 3, 4], [:a :b; :c :d]])
-    @test Interfaces.test(IterationInterface, Base.Generator, [(i for i in 1:5), (i for i in 1:5)])
-    @test Interfaces.test(IterationInterface, Tuple, [(1, 2, 3, 4)])
-end
-
-@testset "SetInterface" begin
-    @test Interfaces.test(SetInterface, Set, [Set((1, 2))])
-    @test Interfaces.test(SetInterface, BitSet, [BitSet((1, 2))])
-    @test Interfaces.test(SetInterface, Base.KeySet, [Base.KeySet(Dict(:a=>1, :b=>2))])
-    @test Interfaces.test(SetInterface, Test.GenericSet, [Test.GenericSet(Set((1, 2)))])
-    s = Base.IdSet(); push!(s, "a"); push!(s, "b")
-    @test Interfaces.test(SetInterface, Base.IdSet, [s]) 
-end
+@test_broken Interfaces.test(ArrayInterface, Base.LogicalIndex, [to_indices([1, 2, 3], ([false, true, true],))[1]])

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -2,8 +2,10 @@ using BaseInterfaces
 using Interfaces
 using Test
 
+# Test some Test objects
 @implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint!)} Test.GenericSet [Test.GenericSet(Set((1, 2)))]
 @implements DictInterface Test.GenericDict [Arguments(d=Test.GenericDict(Dict(:a => 1, :b => 2)), k=:c, v=3)]
+@test Interfaces.test(Main)
 
 # Test all interfaaces in BaseInterfaces
 @test Interfaces.test(BaseInterfaces)
@@ -14,4 +16,13 @@ using Test
 @test Interfaces.test(IterationInterface, BaseInterfaces)
 @test Interfaces.test(SetInterface, BaseInterfaces)
 
+# Now test all the interfaces implementations independent of where they are implemented
+@test Interfaces.test(ArrayInterface)
+@test Interfaces.test(DictInterface)
+@test Interfaces.test(IterationInterface)
+@test Interfaces.test(SetInterface)
+
+@test_throws ArgumentError Interfaces.test(SetInterface{:empty})
+
+# We can't implement LogicalIndex as it breaks the documented Base AbstractArray interface
 @test_broken Interfaces.test(ArrayInterface, Base.LogicalIndex, [to_indices([1, 2, 3], ([false, true, true],))[1]])

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -5,6 +5,13 @@ using Test
 @implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint!)} Test.GenericSet [Test.GenericSet(Set((1, 2)))]
 @implements DictInterface Test.GenericDict [Arguments(d=Test.GenericDict(Dict(:a => 1, :b => 2)), k=:c, v=3)]
 
-Interfaces.test(BaseInterfaces)
+# Test all interfaaces in BaseInterfaces
+@test Interfaces.test(BaseInterfaces)
+
+# Or test each interface in the module individually
+@test Interfaces.test(ArrayInterface, BaseInterfaces)
+@test Interfaces.test(DictInterface, BaseInterfaces)
+@test Interfaces.test(IterationInterface, BaseInterfaces)
+@test Interfaces.test(SetInterface, BaseInterfaces)
 
 @test_broken Interfaces.test(ArrayInterface, Base.LogicalIndex, [to_indices([1, 2, 3], ([false, true, true],))[1]])

--- a/BaseInterfaces/test/runtests.jl
+++ b/BaseInterfaces/test/runtests.jl
@@ -5,10 +5,13 @@ using Test
 # Test some Test objects
 @implements SetInterface{(:empty,:emptymutable,:hasfastin,:intersect,:union,:sizehint!)} Test.GenericSet [Test.GenericSet(Set((1, 2)))]
 @implements DictInterface Test.GenericDict [Arguments(d=Test.GenericDict(Dict(:a => 1, :b => 2)), k=:c, v=3)]
-@test Interfaces.test(Main)
+
+# Test all interfaces
+@test Interfaces.test()
 
 # Test all interfaaces in BaseInterfaces
 @test Interfaces.test(BaseInterfaces)
+@test Interfaces.test(Main)
 
 # Or test each interface in the module individually
 @test Interfaces.test(ArrayInterface, BaseInterfaces)

--- a/src/implements.jl
+++ b/src/implements.jl
@@ -20,15 +20,11 @@ implements(::Type{<:Interface}, obj::Type) = false
 
 """
     @implements(interface, objtype)
-    @implements(dev, interface, objtype)
 
 Declare that an interface implements an interface, or multipleinterfaces.
 
 The macro can only be used once per module for any one type. To define
 multiple interfaces a type implements, combine them in square brackets.
-
-Passing the keyword `dev` as the first argument lets us show test output during development.
-Do not use `dev` in production code, or output will appear during package precompilation.
 
 # Example
 
@@ -42,10 +38,6 @@ using BaseInterfaces
 """
 macro implements(interface, objtype, test_objects)
     _implements_inner(interface, objtype, test_objects)
-end
-macro implements(dev::Symbol, interface, objtype, test_objects)
-    dev == :dev || error("3 arg version of `@implements must start with `dev`, and should only be used in testing")
-    _implements_inner(interface, objtype, test_objects; show=true)
 end
 function _implements_inner(interface, objtype, test_objects; show=false)
     if interface isa Expr && interface.head == :curly

--- a/src/implements.jl
+++ b/src/implements.jl
@@ -40,14 +40,14 @@ using BaseInterfaces
 @implements BaseInterfaces.IterationInterface{(:indexing,:reverse)} MyObject
 ```
 """
-macro implements(interface, objtype)
-    _implements_inner(interface, objtype)
+macro implements(interface, objtype, test_objects)
+    _implements_inner(interface, objtype, test_objects)
 end
-macro implements(dev::Symbol, interface, objtype)
+macro implements(dev::Symbol, interface, objtype, test_objects)
     dev == :dev || error("3 arg version of `@implements must start with `dev`, and should only be used in testing")
-    _implements_inner(interface, objtype; show=true)
+    _implements_inner(interface, objtype, test_objects; show=true)
 end
-function _implements_inner(interface, objtype; show=false)
+function _implements_inner(interface, objtype, test_objects; show=false)
     if interface isa Expr && interface.head == :curly
         interfacetype = interface.args[1]    
         optional_keys = interface.args[2]
@@ -70,6 +70,7 @@ function _implements_inner(interface, objtype; show=false)
             $Interfaces._all_in(Options, $Interfaces.optional_keys(T, O))
         # Define which optional components the object implements
         $Interfaces.optional_keys(::Type{<:$interfacetype}, ::Type{<:$objtype}) = $optional_keys
+        $Interfaces.test_objects(::Type{<:$interfacetype}, ::Type{<:$objtype}) = $test_objects
         nothing
     end |> esc
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -9,7 +9,7 @@ Components is an `Tuple` of `Symbol`.
 abstract type Interface{Components} end
 
 """
-    optional_keys(T::Type{<:Interface}, obj::Type)
+    optional_keys(T::Type{<:Interface}, O::Type)
 
 Get the keys for the optional components of an [`Interface`](@ref),
 as a tuple os `Symbol`.
@@ -20,6 +20,13 @@ optional_keys(T::Type{<:Interface}, obj::Type) = ()
 optional_keys(T::Type{<:Interface}) = keys(components(T).optional)
 
 mandatory_keys(T::Type{<:Interface}, args...) = keys(components(T).mandatory)
+
+"""
+    test_objects(T::Type{<:Interface}, O::Type)
+
+Get the test object(s) for type `O` and interface `T`.
+"""
+function test_objects end
 
 """
     description(::Type{<:Interface})

--- a/src/test.jl
+++ b/src/test.jl
@@ -64,9 +64,16 @@ interfaces available and test them.
 """
 function test end
 test(; kw...) = _test_module_implements(Any, nothing; kw...)
-test(T::Type{<:Interface}, mod::Module; kw...) = _test_module_implements(Type{T}, mod; kw...)
+test(T::Type{<:Interface}, mod::Module; kw...) =
+    _test_module_implements(Type{_check_no_options(T)}, mod; kw...)
 test(mod::Module; kw...) = _test_module_implements(Any, mod; kw...)
-test(T::Type{<:Interface}; kw...) = _test_module_implements(Type{T}, nothing; kw...)
+test(T::Type{<:Interface}; kw...) =
+    _test_module_implements(Type{_check_no_options(T)}, nothing; kw...)
+
+function _check_no_options(T)
+    T isa UnionAll || throw(ArgumentError("Interface options not accepted for more than one implementation"))
+    return T
+end
 # Here we test all the `implements` methods in `methodlist` that were defined in `mod`.
 # Basically we are using the `implements` method table as the global state of all
 # available implementations.

--- a/src/test.jl
+++ b/src/test.jl
@@ -64,10 +64,9 @@ end
 function _test_module(mod, methodlist; kw...)
     all(methodlist) do m
         m.module == mod || return true
-        b = m.sig isa UnionAll ? m.sig.body : m.sig
         # We make this signature in the @interface macro
         # so we know it is this consistent
-
+        b = m.sig isa UnionAll ? m.sig.body : m.sig
         t = b.parameters[2].var.ub
         if t isa UnionAll
             T = t.body.name.wrapper

--- a/src/test.jl
+++ b/src/test.jl
@@ -50,7 +50,7 @@ returning `true` or `false`.
 If no interface type is passed, Interfaces.jl will find all the
 interfaces available and test them.
 """
-function test(T::Type, mod::Module; kw...) 
+function test(T::Type{<:Interface}, mod::Module; kw...) 
     methodlist = methods(implements, Tuple{T,<:Any})
     _test_module(mod, methodlist; kw...)
 end

--- a/src/test.jl
+++ b/src/test.jl
@@ -41,7 +41,8 @@ function check_coherent_types(O::Type, tow::TestObjectWrapper)
 end
 
 """
-    test(::Type{<:Interface}, module::Module)
+    test(m::Module)
+    test(::Type{<:Interface}, m::Module)
     test(::Type{<:Interface}, obj::Type)
 
 Test if an interface is implemented correctly for an object,

--- a/test/advanced.jl
+++ b/test/advanced.jl
@@ -67,7 +67,7 @@ Interfaces.test(Group.GroupInterface, Float64, float_pairs)
 
 # We can thus declare proudly
 
-@implements Group.GroupInterface Float64
+@implements Group.GroupInterface Float64 [Arguments(x = 2.0, y = 1.0)]
 
 #=
 Now we check it for integer numbers.
@@ -99,6 +99,6 @@ In summary, there are two things to remember:
 
 using Test  #src
 
-@test Interfaces.test(Group.GroupInterface, Float64, float_pairs)  #src
-@test !Interfaces.test(Group.GroupInterface, Int, int_pairs)  #src
+@test Interfaces.test(Group.GroupInterface, Float64)  #src
+@test !Interfaces.test(Group.GroupInterface, int_pairs)  #src
 @test_throws ArgumentError Interfaces.test(Group.GroupInterface, Float64, int_pairs)  #src

--- a/test/advanced.jl
+++ b/test/advanced.jl
@@ -100,5 +100,5 @@ In summary, there are two things to remember:
 using Test  #src
 
 @test Interfaces.test(Group.GroupInterface, Float64)  #src
-@test !Interfaces.test(Group.GroupInterface, int_pairs)  #src
+@test !Interfaces.test(Group.GroupInterface, Int, int_pairs)  #src
 @test_throws ArgumentError Interfaces.test(Group.GroupInterface, Float64, int_pairs)  #src

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -79,15 +79,15 @@ The `@implements` macro takes two arguments.
 2. The type for which the interface is implemented.
 =#
 
-@implements Animals.AnimalInterface{(:walk,:talk)} Duck
+@implements Animals.AnimalInterface{(:walk,:talk)} Duck [Duck(1), Duck(2)]
 
 # Now let's see what happens when the interface is not correctly implemented.
 struct Chicken <: Animals.Animal end
 
 # As expected, the tests fail
-chickens = [Chicken()]
+chickens = 
 try
-    Interfaces.test(Animals.AnimalInterface, Chicken, chickens)
+    Interfaces.test(Animals.AnimalInterface, Chicken)
 catch e
     print(e)
 end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -85,9 +85,9 @@ The `@implements` macro takes two arguments.
 struct Chicken <: Animals.Animal end
 
 # As expected, the tests fail
-chickens = 
+chickens = [Chicken()]
 try
-    Interfaces.test(Animals.AnimalInterface, Chicken)
+    Interfaces.test(Animals.AnimalInterface, Chicken, chickens)
 catch e
     print(e)
 end


### PR DESCRIPTION
This PR moves test objects back to the `@implements` macro, and implements the `test` method for Module:

```julia
@test Interfaces.test(SomeModule)
```

Which cuts a huge amount of code from BaseInterfaces.jl and ensures everything implemented is tested.

Closes #35