### PR TITLE
add InterfacesCore subpackage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install Julia dependencies
-          shell: julia --project=monorepo {0}
+          shell: julia
           run: |
             using Pkg;
             # dev sub packages 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,15 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Install Julia dependencies
+          shell: julia --project=monorepo {0}
+          run: |
+            using Pkg;
+            # dev sub packages 
+            pkg"dev . ./BaseInterfaces ./InterfacesCore"
+      - name: Run InterfacesCore tests
+        run: julia --project=InterfacesCore -e 'using Pkg; pkg"dev ."; pkg"update"; pkg"test"'
+        shell: bash
       - uses: julia-actions/julia-runtest@v1
       - name: Run BaseInterfaces tests
         run: julia --project=BaseInterfaces -e 'using Pkg; pkg"dev ."; pkg"update"; pkg"test"'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install Julia dependencies
-          shell: julia
+          shell: julia --project=./ {0}
           run: |
             using Pkg;
             # dev sub packages 

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -18,8 +18,12 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; pkg"dev ."; pkg"dev ./BaseInterfaces"; Pkg.instantiate()'
+      - name: Install Julia dependencies
+          shell: julia --project=docs/
+          run: |
+            using Pkg;
+            # dev sub packages 
+            pkg"dev . ./BaseInterfaces ./InterfacesCore"
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token

--- a/InterfacesCore/LICENSE
+++ b/InterfacesCore/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Rafael Schouten <rafaelschouten@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/InterfacesCore/Project.toml
+++ b/InterfacesCore/Project.toml
@@ -1,0 +1,14 @@
+name = "InterfacesCore"
+uuid = "a94bad63-e719-4205-a4a7-d6d26991555a"
+authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
+version = "0.1"
+
+[compat]
+Test = "1"
+julia = "1.6"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/InterfacesCore/README.md
+++ b/InterfacesCore/README.md
@@ -1,0 +1,36 @@
+# BaseInterfaces
+
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://rafaqz.github.io/Interfaces.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://rafaqz.github.io/Interfaces.jl/dev/)
+[![Build Status](https://github.com/rafaqz/Interfaces.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/rafaqz/Interfaces.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/rafaqz/Interfaces.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/rafaqz/Interfaces.jl)
+
+BaseInterfaces.jl is a subpackage of Interfaces.jl that provides predifined 
+definition and testing for Base Julia interfaces.
+
+Currently this includes:
+- A general iteration interface: `IterationInterface`
+- `AbstractArray` interface: `ArrayInterface`
+- `AbstractSet` interface: `SetInterface`
+- `AbstractDict` interface: `DictInterface`
+
+
+Testing your object follows the interfaces is as simple as:
+
+```julia
+using BaseInterfaces, Interfaces
+Interfaces.tests(DictInterface, MyDict, [mydict1, mydict2, ...])
+```
+
+Declaring that it follows the interface is done with:
+
+```julia
+@implements DictInterface{(:component1, :component2)} MyDict
+```
+
+Where components can be chosen from `Interfaces.optional_keys(DictInterface)`.
+
+See [the docs](https://rafaqz.github.io/Interfaces.jl/stable/) for use.
+
+If you want to add more Base julia interfaces here, or think the existing 
+ones could be improved, please make an issue or pull request.

--- a/InterfacesCore/src/InterfacesCore.jl
+++ b/InterfacesCore/src/InterfacesCore.jl
@@ -1,0 +1,19 @@
+module InterfacesCore
+
+export Interface, @interface_type
+
+"""
+    Interface{Components}
+
+Abstract supertype for all Interfaces.jl interfaces.
+
+Components is an `Tuple` of `Symbol`.
+"""
+
+abstract type Interface{Components} end
+
+macro interface_type(interface::Symbol)
+    :(abstract type $interface{Components} <: $InterfacesCore.Interface{Components} end) |> esc
+end
+
+end

--- a/InterfacesCore/src/InterfacesCore.jl
+++ b/InterfacesCore/src/InterfacesCore.jl
@@ -19,7 +19,7 @@ Components is an `Tuple` of `Symbol`.
 
 abstract type Interface{Components} end
 
-macro interface_type(interface::Symbol, type)
+macro interface_core(interface::Symbol, type)
     quote
         @assert $type isa Type
         abstract type $interface{Components} <: $InterfacesCore.Interface{Components} end

--- a/InterfacesCore/src/InterfacesCore.jl
+++ b/InterfacesCore/src/InterfacesCore.jl
@@ -1,6 +1,13 @@
 module InterfacesCore
 
-export Interface, @interface_type
+export Interface, requiredtype, @interface_type
+
+"""
+    requiredtype(::Type{<:Interface})
+
+Returns the supertype required for all interface implementations.
+"""
+function requiredtype end
 
 """
     Interface{Components}
@@ -12,8 +19,11 @@ Components is an `Tuple` of `Symbol`.
 
 abstract type Interface{Components} end
 
-macro interface_type(interface::Symbol)
-    :(abstract type $interface{Components} <: $InterfacesCore.Interface{Components} end) |> esc
+macro interface_type(interface::Symbol, type)
+    quote
+        @assert $type isa Type
+        abstract type $interface{Components} <: $InterfacesCore.Interface{Components} end
+    end |> esc
 end
 
 end

--- a/InterfacesCore/test/runtests.jl
+++ b/InterfacesCore/test/runtests.jl
@@ -1,4 +1,4 @@
 using InterfacesCore, Test
 
-@interface_type TestInterface 
+@interface_core TestInterface 
 @test TestInterface <: Interface

--- a/InterfacesCore/test/runtests.jl
+++ b/InterfacesCore/test/runtests.jl
@@ -1,0 +1,4 @@
+using InterfacesCore, Test
+
+@interface_type TestInterface 
+@test TestInterface <: Interface

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,14 @@ uuid = "85a1e053-f937-4924-92a5-1367d23b7b87"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
 version = "0.3.0"
 
+[deps]
+InterfacesCore = "a94bad63-e719-4205-a4a7-d6d26991555a"
+
 [compat]
+Aqua = "0.8"
+Documenter = "1"
+InterfacesCore = "0.1"
+Test = "1"
 julia = "1.6"
 
 [extras]

--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -5,6 +5,8 @@ A Julia package for specifying and testing interfaces (conditions verified by a 
 """
 module Interfaces
 
+using InterfacesCore
+
 export Arguments
 export @implements, @interface
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,14 +1,5 @@
 
 """
-    Interface{Components}
-
-Abstract supertype for all Interfaces.jl interfaces.
-
-Components is an `Tuple` of `Symbol`.
-"""
-abstract type Interface{Components} end
-
-"""
     optional_keys(T::Type{<:Interface}, O::Type)
 
 Get the keys for the optional components of an [`Interface`](@ref),

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -34,13 +34,6 @@ Returns the components of the interface, as a `NamedTuple` of `NamedTuple`.
 function components end
 
 """
-    requiredtype(::Type{<:Interface})
-
-Returns the supertype required for all interface implementations.
-"""
-function requiredtype end
-
-"""
 @interface(interfacename, components, [description])
 
 Define an interface that can apply to types `<: Any`.
@@ -58,15 +51,17 @@ description = "A description of the interface"
 @interface MyInterface Any components description
 ```
 """
-macro interface(interface::Symbol, type, components, description)
+macro interface(interface::Symbol, type, components, description="")
     quote
         @assert $type isa Type
         @assert $components isa NamedTuple{(:mandatory,:optional)}
         @assert $description isa String
-        # Define the interface type (should it be concrete?)
-        abstract type $interface{Components} <: $Interfaces.Interface{Components} end
+        # Define the interface type if its for the local scope
+        if $interface isa Symbol
+            abstract type $interface{Components} <: $InterfacesCore.Interface{Components} end
+        end
         # Define the interface component methods
-        $Interfaces.requiredtype(::Type{<:$interface}) = $type
+        $InterfacesCore.requiredtype(::Type{<:$interface}) = $type
         $Interfaces.components(::Type{<:$interface}) = $components
         $Interfaces.description(::Type{<:$interface}) = $description
         # Generate a docstring for the interface

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using Aqua
 using Documenter
 using Interfaces
 using Test
-using Aqua
 
 @testset verbose = true "Interfaces.jl" begin
     # Formal tests


### PR DESCRIPTION
This PR adds an InterfacesCore.jl subpackage.

All it implements is `abstract type Interface end` and a `@interface_type` macro.


The reason for this is so we can define the interface type without any package overheads, and add Interfaces.jl as an extension. This means packages can just go `using Interfaces` and test their implementation, rather than needing to load another package.

We cant  use extensions currently because the type would be defined in the extension, and not be accessible to anyone.