### PR TITLE
Generate `# Extended help` with all component descriptions

### DIFF
--- a/src/Interfaces.jl
+++ b/src/Interfaces.jl
@@ -10,6 +10,7 @@ export @implements, @interface
 
 include("arguments.jl")
 include("interface.jl")
+include("documentation.jl")
 include("implements.jl")
 include("test.jl")
 

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -3,3 +3,24 @@ function header(interface::Type{<:Interface})
     o_keys = optional_keys(interface)
     return "An Interfaces.jl `Interface` with mandatory components `$m_keys` and optional components `$o_keys`."
 end
+
+function extended_help(@nospecialize(interface::Type{<:Interface}))
+    m_keys = mandatory_keys(interface)
+    o_keys = optional_keys(interface)
+
+    io_buf = IOBuffer()
+    # ^(More efficient and readable than string concatenation)
+
+    println(io_buf, "# Extended help\n")
+    println(io_buf, "## Mandatory keys:\n")
+    for (key, (value, _)) in m_keys
+        println(io_buf, "* `$key`: $value")
+    end
+
+    println(io_buf, "\n## Optional keys:\n")
+    for (key, (value, _)) in o_keys
+        println(io_buf, "* `$key`: $value")
+    end
+
+    return String(take!(io_buf))
+end

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -1,0 +1,5 @@
+function header(interface::Type{<:Interface})
+    m_keys = mandatory_keys(interface)
+    o_keys = optional_keys(interface)
+    return "An Interfaces.jl `Interface` with mandatory components `$m_keys` and optional components `$o_keys`."
+end

--- a/src/documentation.jl
+++ b/src/documentation.jl
@@ -4,22 +4,37 @@ function header(interface::Type{<:Interface})
     return "An Interfaces.jl `Interface` with mandatory components `$m_keys` and optional components `$o_keys`."
 end
 
-function extended_help(@nospecialize(interface::Type{<:Interface}))
-    m_keys = mandatory_keys(interface)
-    o_keys = optional_keys(interface)
+function extended_help(interface::Type{<:Interface})
+    comp = components(interface)
 
     io_buf = IOBuffer()
     # ^(More efficient and readable than string concatenation)
 
-    println(io_buf, "# Extended help\n")
-    println(io_buf, "## Mandatory keys:\n")
-    for (key, (value, _)) in m_keys
-        println(io_buf, "* `$key`: $value")
+    println(io_buf, "# Extended help")
+    !isempty(comp.mandatory) && println(io_buf, "\n## Mandatory keys:\n")
+    for key in keys(comp.mandatory)
+        values = comp.mandatory[key]
+        if values isa Tuple
+            println(io_buf, "* `$key`:")
+            for value in values
+                println(io_buf, "  * $(first(value))")
+            end
+        else
+            println(io_buf, "* `$key`: $(first(values))")
+        end
     end
 
-    println(io_buf, "\n## Optional keys:\n")
-    for (key, (value, _)) in o_keys
-        println(io_buf, "* `$key`: $value")
+    !isempty(comp.optional) && println(io_buf, "\n## Optional keys:\n")
+    for key in keys(comp.optional)
+        values = comp.optional[key]
+        if values isa Tuple
+            println(io_buf, "* `$key`:")
+            for value in values
+                println(io_buf, "  * $(first(value))")
+            end
+        else
+            println(io_buf, "* `$key`: $(first(values))")
+        end
     end
 
     return String(take!(io_buf))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -81,12 +81,11 @@ macro interface(interface::Symbol, type, components, description)
         # Generate a docstring for the interface
         let description=$description,
             interfacesym=$(QuoteNode(interface)),
-            m_keys=$Interfaces.mandatory_keys($interface),
-            o_keys=$Interfaces.optional_keys($interface)
+            header=$Interfaces.header($interface)
             @doc """
                 $("   ") $interfacesym
 
-            An Interfaces.jl `Interface` with mandatory components `$m_keys` and optional components `$o_keys`.
+            $header
 
             $description
             """ $interface 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -81,13 +81,16 @@ macro interface(interface::Symbol, type, components, description)
         # Generate a docstring for the interface
         let description=$description,
             interfacesym=$(QuoteNode(interface)),
-            header=$Interfaces.header($interface)
+            header=$Interfaces.header($interface),
+            extended_help=$Interfaces.extended_help($interface)
             @doc """
                 $("   ") $interfacesym
 
             $header
 
             $description
+
+            $extended_help
             """ $interface 
         end
     end |> esc

--- a/test/advanced.jl
+++ b/test/advanced.jl
@@ -102,3 +102,46 @@ using Test  #src
 @test Interfaces.test(Group.GroupInterface, Float64)  #src
 @test !Interfaces.test(Group.GroupInterface, Int, int_pairs)  #src
 @test_throws ArgumentError Interfaces.test(Group.GroupInterface, Float64, int_pairs)  #src
+
+# Test generated docs
+expected_extended_help = """# Extended help
+
+## Mandatory keys:
+
+* `neutral_check`:
+  * neutral stable
+* `multiplication_check`:
+  * multiplication stable
+* `inversion_check`:
+  * inversion stable
+  * inversion works"""
+
+@test strip(Interfaces.extended_help(Group.GroupInterface)) == strip(expected_extended_help)
+
+
+expected_docs = """```
+    GroupInterface
+```
+
+An Interfaces.jl `Interface` with mandatory components `(:neutral_check, :multiplication_check, :inversion_check)` and optional components `()`.
+
+A group is a set of elements with a neutral element where you can perform multiplications and inversions.
+
+The conditions checking the interface accept an `Arguments` object with two fields named `x` and `y`. The type of the first field `x` must be the type you wish to declare as implementing `GroupInterface`.
+
+# Extended help
+
+## Mandatory keys:
+
+  * `neutral_check`:
+
+      * neutral stable
+  * `multiplication_check`:
+
+      * multiplication stable
+  * `inversion_check`:
+
+      * inversion stable
+      * inversion works"""
+
+@test strip(string(@doc Group.GroupInterface)) == strip(expected_docs)


### PR DESCRIPTION
This adds an automatically-generated `# Extended help` section with all component descriptions.

This won't appear in the normal docs for `?`, only for `??` which is the extended help, as described in #46.

Using my package's NodeInterface as an example, here is the before:

<details><summary>(Expand)</summary>

```markdown
'''
    NodeInterface
'''

An Interfaces.jl `Interface` with mandatory components `(:create_node, :copy, :hash, :any, :equality, :preserve_sharing, :constructorof, :eltype, :with_type_parameters, :default_allocator, :set_node!, :count_nodes, :tree_mapreduce)` and optional components `(:leaf_copy, :leaf_hash, :leaf_equal, :branch_copy, :branch_hash, :branch_equal, :count_depth, :is_node_constant, :count_constants, :filter_map, :has_constants, :get_constants, :set_constants!, :index_constants, :has_operators)`.

Defines the interface for [`AbstractExpressionNode`](@ref) which can include various operations such as copying, hashing, and checking equality, as well as tree-specific operations like map-reduce and node manipulation.
```

</details>

<details><summary>And the after:</summary>

```markdown
'''
    NodeInterface
'''

An Interfaces.jl `Interface` with mandatory components `(:create_node, :copy, :hash, :any, :equality, :preserve_sharing, :constructorof, :eltype, :with_type_parameters, :default_allocator, :set_node!, :count_nodes, :tree_mapreduce)` and optional components `(:leaf_copy, :leaf_hash, :leaf_equal, :branch_copy, :branch_hash, :branch_equal, :count_depth, :is_node_constant, :count_constants, :filter_map, :has_constants, :get_constants, :set_constants!, :index_constants, :has_operators)`.

Defines the interface for [`AbstractExpressionNode`](@ref) which can include various operations such as copying, hashing, and checking equality, as well as tree-specific operations like map-reduce and node manipulation.

# Extended help

## Mandatory keys:

  * `create_node`: creates a new instance of the node type
  * `copy`: returns a copy of the tree
  * `hash`: returns the hash of the tree
  * `any`: checks if any element of the tree satisfies a condition
  * `equality`: checks equality of the tree with itself and its copy
  * `preserve_sharing`: checks if the node type preserves sharing
  * `constructorof`: gets the constructor function for a node type
  * `eltype`: gets the element type of the node
  * `with_type_parameters`: applies type parameters to the node type
  * `default_allocator`: gets the default allocator for the node type
  * `set_node!`: sets the node's value
  * `count_nodes`: counts the number of nodes in the tree
  * `tree_mapreduce`: applies a function across the tree

## Optional keys:

  * `leaf_copy`: copies a leaf node
  * `leaf_hash`: computes the hash of a leaf node
  * `leaf_equal`: checks equality of two leaf nodes
  * `branch_copy`: copies a branch node
  * `branch_hash`: computes the hash of a branch node
  * `branch_equal`: checks equality of two branch nodes
  * `count_depth`: calculates the depth of the tree
  * `is_node_constant`: checks if the node is a constant
  * `count_constants`: counts the number of constants
  * `filter_map`: applies a filter and map function to the tree
  * `has_constants`: checks if the tree has constants
  * `get_constants`: gets constants from the tree, returning a tuple of: (1) a flat vector of the constants, and (2) a reference object that can be used by `set_constants!` to efficiently set them back
  * `set_constants!`: sets constants in the tree, given: (1) a flat vector of constants, (2) the tree, and (3) the reference object produced by `get_constants`
  * `index_constants`: indexes constants in the tree
  * `has_operators`: checks if the tree has operators
```

</details>

For multiple methods, it generates a nested list.

<details><summary>For example, for the GroupInterface:</summary>

```markdown
'''
    GroupInterface
'''

An Interfaces.jl `Interface` with mandatory components `(:neutral_check, :multiplication_check, :inversion_check)` and optional components `()`.

A group is a set of elements with a neutral element where you can perform multiplications and inversions.

The conditions checking the interface accept an `Arguments` object with two fields named `x` and `y`. The type of the first field `x` must be the type you wish to declare as implementing `GroupInterface`.

# Extended help

## Mandatory keys:

  * `neutral_check`:

      * neutral stable
  * `multiplication_check`:

      * multiplication stable
  * `inversion_check`:

      * inversion stable
      * inversion works
```

</details>

