### PR TITLE
add single arg `test_objects`

### DIFF
--- a/test/basic.jl
+++ b/test/basic.jl
@@ -105,6 +105,7 @@ using Test  #src
     @test Interfaces.test(Animals.AnimalInterface) == true # Test all implemented types for AnimalInterface
     # TODO wrap errors somehow, or just let Invariants.jl handle that.  #src
     @test_throws Interfaces.InterfaceError Interfaces.test(Animals.AnimalInterface{:dig}, Duck)  #src
+    @test Interfaces.test_objects(Animals.AnimalInterface) == Dict(Duck => ducks)
 end  #src
 
 @testset "Chicken" begin  #src


### PR DESCRIPTION
@datseris this PR implements the single argument `test_objects` method.

It returns a Dict of ObjType => test_object_vector

Closes #49